### PR TITLE
fix: Quick Generate uses beam search only

### DIFF
--- a/product-reconciliation/v2/v2 repo/src/engine/evaluation/canonicalEvaluator.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/evaluation/canonicalEvaluator.ts
@@ -19,8 +19,8 @@
 
 import { type Layout } from '../../types/layout';
 import { type FingerType, type HandSide } from '../../types/fingerModel';
-import { type HandPose, type InstrumentConfig } from '../../types/performance';
-import { type PerformanceMoment, type NoteInstance } from '../../types/performanceEvent';
+import { type InstrumentConfig } from '../../types/performance';
+import { type PerformanceMoment } from '../../types/performanceEvent';
 import { type PadFingerAssignment } from '../../types/executionPlan';
 import { type EvaluationConfig } from '../../types/evaluationConfig';
 import {
@@ -37,14 +37,12 @@ import {
   createZeroCostDimensions,
   sumCostDimensions,
   averageCostDimensions,
-  computeTotal,
 } from '../../types/costBreakdown';
-import { type FeasibilityVerdict, deriveFeasibilityVerdict } from '../../types/diagnostics';
+import { deriveFeasibilityVerdict } from '../../types/diagnostics';
 import { type ConstraintTier } from '../prior/feasibility';
-import { padKey, parsePadKey } from '../../types/padGrid';
+import { padKey } from '../../types/padGrid';
 
 import {
-  calculatePoseNaturalness,
   calculateTransitionCost,
   calculateAttractorCost,
   calculatePerFingerHomeCost,
@@ -326,8 +324,9 @@ export function evaluatePerformance(input: EvaluatePerformanceInput): Performanc
   }
 
   // Pre-build indexes once for the whole performance
-  const voiceIdIndex = buildVoiceIdToPadIndex(layout.padToVoice);
-  const noteIndex = buildNoteToPadIndex(layout.padToVoice);
+  // TODO: use these indexes for moment-level pad resolution
+  void buildVoiceIdToPadIndex(layout.padToVoice);
+  void buildNoteToPadIndex(layout.padToVoice);
 
   const eventCosts: EventCostBreakdown[] = [];
   const transitionCosts: TransitionCostBreakdown[] = [];

--- a/product-reconciliation/v2/v2 repo/src/engine/evaluation/poseBuilder.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/evaluation/poseBuilder.ts
@@ -8,7 +8,7 @@
 
 import { type FingerType, type HandSide } from '../../types/fingerModel';
 import { type FingerCoordinate, type HandPose } from '../../types/performance';
-import { type PadCoord, parsePadKey } from '../../types/padGrid';
+import { parsePadKey } from '../../types/padGrid';
 import { type PadFingerAssignment } from '../../types/executionPlan';
 import { type ConstraintTier } from '../prior/feasibility';
 import {

--- a/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
@@ -328,11 +328,11 @@ export async function generateCandidates(
     let executionPlan;
     let finalLayout = layout;
 
-    // Determine whether to use annealing and which config
-    // optimizationMode takes precedence over legacy useAnnealing flag
-    const shouldAnneal = config.optimizationMode !== undefined
-      ? true  // Both 'fast' and 'deep' modes use annealing
-      : (config.useAnnealing ?? false);
+    // Determine whether to use annealing and which config.
+    // Only 'deep' mode uses annealing (thousands of iterations).
+    // 'fast' mode uses beam search only for near-instant results.
+    const shouldAnneal = config.optimizationMode === 'deep'
+      || (config.optimizationMode === undefined && (config.useAnnealing ?? false));
 
     const annealingConfig = config.optimizationMode === 'deep'
       ? DEEP_ANNEALING_CONFIG

--- a/product-reconciliation/v2/v2 repo/src/types/costBreakdown.ts
+++ b/product-reconciliation/v2/v2 repo/src/types/costBreakdown.ts
@@ -10,7 +10,7 @@
  */
 
 import { type FingerType, type HandSide } from './fingerModel';
-import { type FeasibilityLevel, type FeasibilityVerdict } from './diagnostics';
+import { type FeasibilityVerdict } from './diagnostics';
 import { type HandPose } from './performance';
 import { type PadFingerAssignment } from './executionPlan';
 import { type ConstraintTier } from '../engine/prior/feasibility';

--- a/product-reconciliation/v2/v2 repo/src/ui/hooks/useAutoAnalysis.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/hooks/useAutoAnalysis.ts
@@ -199,7 +199,6 @@ export function useAutoAnalysis() {
           performance,
           { ...state.engineConfig, beamWidth: 15 }, // Fast mode
           manualAssignments,
-          solverConstraints,
         );
 
         if (abortRef.current) return;


### PR DESCRIPTION
## Summary
- **Root cause**: Quick mode was running simulated annealing (3000 iterations × 3 candidates = ~2.5 minutes) instead of beam search only, making the Generate button appear broken
- Fixed `shouldAnneal` logic in `multiCandidateGenerator.ts` so only Deep/Thorough mode runs annealing
- Removed extra `solver.solve()` argument in `useAutoAnalysis.ts` (TS2554 fix)
- Cleaned up unused imports across `canonicalEvaluator.ts`, `poseBuilder.ts`, `costBreakdown.ts`

## Test plan
- [x] 475 tests passing
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Verified in browser: Generate completes near-instantly, produces pad assignments with finger assignments
- [x] Deep/Thorough mode still uses annealing as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)