### PR TITLE
Add Atomic Constraint Validator

### DIFF
--- a/product-reconciliation/v2/v2 repo/src/ui/App.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/App.tsx
@@ -8,6 +8,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { ProjectLibraryPage } from './pages/ProjectLibraryPage';
 import { ProjectEditorPage } from './pages/ProjectEditorPage';
 import { OptimizerDebugPage } from './pages/OptimizerDebugPage';
+import { ConstraintValidatorPage } from './pages/ConstraintValidatorPage';
 
 export function App() {
   return (
@@ -17,6 +18,7 @@ export function App() {
           <Route path="/" element={<ProjectLibraryPage />} />
           <Route path="/project/:id" element={<ProjectEditorPage />} />
           <Route path="/optimizer-debug" element={<OptimizerDebugPage />} />
+          <Route path="/validator" element={<ConstraintValidatorPage />} />
         </Routes>
       </div>
     </BrowserRouter>

--- a/product-reconciliation/v2/v2 repo/src/ui/fixtures/feasibilityDemos.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/fixtures/feasibilityDemos.ts
@@ -308,10 +308,12 @@ function buildFeasibilityDemo(scenario: FeasibilityDemoScenario): ProjectState {
 // Public API
 // ============================================================================
 
-/** All feasibility demo project generators. */
-const FEASIBILITY_DEMOS = SCENARIOS.map(s => () => buildFeasibilityDemo(s));
+/** Temporal-only feasibility demo project generators (A1-A8 replaced by Constraint Validator). */
+const FEASIBILITY_DEMOS = SCENARIOS
+  .filter(s => !s.id.startsWith('A'))
+  .map(s => () => buildFeasibilityDemo(s));
 
-/** Get all feasibility demo projects. Regenerated fresh on each call. */
+/** Get temporal feasibility demo projects. Regenerated fresh on each call. */
 export function getFeasibilityDemos(): ProjectState[] {
   return FEASIBILITY_DEMOS.map(gen => gen());
 }

--- a/product-reconciliation/v2/v2 repo/src/ui/pages/ConstraintValidatorPage.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/pages/ConstraintValidatorPage.tsx
@@ -1,0 +1,186 @@
+/**
+ * Constraint Validator Page.
+ *
+ * Top-level orchestrator for the atomic constraint validator.
+ * Three-panel layout: scenario selection, grid, results.
+ * State management and re-evaluation on edits.
+ *
+ * No solver, no ProjectContext — pure local state.
+ */
+
+import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { type Layout } from '../../types/layout';
+import { type PadFingerAssignment } from '../../types/executionPlan';
+import { type PerformanceMoment } from '../../types/performanceEvent';
+import { type FingerType } from '../../types/fingerModel';
+import { padKey } from '../../types/padGrid';
+import { type ValidatorResult } from '../validator/types';
+import { runValidation, updateMomentPadIds } from '../validator/validatorEngine';
+import { getValidatorScenarios, getValidatorScenario } from '../validator/validatorScenarios';
+import { ValidatorScenarioPanel } from '../validator/ValidatorScenarioPanel';
+import { ValidatorGrid } from '../validator/ValidatorGrid';
+import { ValidatorResultsPanel } from '../validator/ValidatorResultsPanel';
+
+const scenarios = getValidatorScenarios();
+
+function deepCloneLayout(layout: Layout): Layout {
+  return {
+    ...layout,
+    padToVoice: { ...layout.padToVoice },
+    fingerConstraints: { ...layout.fingerConstraints },
+    placementLocks: { ...layout.placementLocks },
+  };
+}
+
+function deepCloneMoment(moment: PerformanceMoment): PerformanceMoment {
+  return {
+    ...moment,
+    notes: moment.notes.map(n => ({ ...n })),
+  };
+}
+
+export function ConstraintValidatorPage() {
+  const navigate = useNavigate();
+  const [selectedId, setSelectedId] = useState(scenarios[0].id);
+  const [layout, setLayout] = useState<Layout>(() => deepCloneLayout(scenarios[0].layout));
+  const [assignment, setAssignment] = useState<PadFingerAssignment>(() => ({ ...scenarios[0].padFingerAssignment }));
+  const [moment, setMoment] = useState<PerformanceMoment>(() => deepCloneMoment(scenarios[0].moment));
+  const [result, setResult] = useState<ValidatorResult | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  // Run validation whenever state changes
+  useEffect(() => {
+    const r = runValidation(layout, assignment, moment);
+    setResult(r);
+  }, [layout, assignment, moment]);
+
+  // Select a new scenario
+  const handleSelectScenario = useCallback((id: string) => {
+    const scenario = getValidatorScenario(id);
+    if (!scenario) return;
+    setSelectedId(id);
+    setLayout(deepCloneLayout(scenario.layout));
+    setAssignment({ ...scenario.padFingerAssignment });
+    setMoment(deepCloneMoment(scenario.moment));
+    setIsDirty(false);
+  }, []);
+
+  // Reset to original scenario state
+  const handleReset = useCallback(() => {
+    const scenario = getValidatorScenario(selectedId);
+    if (!scenario) return;
+    setLayout(deepCloneLayout(scenario.layout));
+    setAssignment({ ...scenario.padFingerAssignment });
+    setMoment(deepCloneMoment(scenario.moment));
+    setIsDirty(false);
+  }, [selectedId]);
+
+  // Move a pad (drag-and-drop)
+  const handleMovePad = useCallback(
+    (fromPadKey: string, toRow: number, toCol: number) => {
+      const toPadKey = padKey(toRow, toCol);
+      const voice = layout.padToVoice[fromPadKey];
+      if (!voice) return;
+
+      // Update layout: move voice from old pad to new pad
+      const newPadToVoice = { ...layout.padToVoice };
+      delete newPadToVoice[fromPadKey];
+      newPadToVoice[toPadKey] = voice;
+      const newLayout: Layout = { ...layout, padToVoice: newPadToVoice };
+
+      // Update assignment: move finger ownership
+      const newAssignment = { ...assignment };
+      if (newAssignment[fromPadKey]) {
+        newAssignment[toPadKey] = newAssignment[fromPadKey];
+        delete newAssignment[fromPadKey];
+      }
+
+      // Update moment padIds
+      const newMoment = updateMomentPadIds(moment, newLayout);
+
+      setLayout(newLayout);
+      setAssignment(newAssignment);
+      setMoment(newMoment);
+      setIsDirty(true);
+    },
+    [layout, assignment, moment],
+  );
+
+  // Reassign a finger
+  const handleReassignFinger = useCallback(
+    (pk: string, hand: 'left' | 'right', finger: FingerType) => {
+      setAssignment(prev => ({
+        ...prev,
+        [pk]: { hand, finger },
+      }));
+      setIsDirty(true);
+    },
+    [],
+  );
+
+  // Compute violated pads from evidence
+  const violatedPads = useMemo(() => {
+    const set = new Set<string>();
+    if (!result) return set;
+    for (const e of result.evidence) {
+      if (e.pads) {
+        for (const p of e.pads) set.add(p);
+      }
+    }
+    return set;
+  }, [result]);
+
+  return (
+    <div className="min-h-screen">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-4">
+          <button
+            onClick={() => navigate('/')}
+            className="text-gray-500 hover:text-gray-300 text-sm transition-colors"
+          >
+            ← Back
+          </button>
+          <h1 className="text-lg font-semibold text-gray-200">
+            Constraint Validator
+          </h1>
+        </div>
+        <span className="text-[10px] text-gray-600 uppercase tracking-wider">
+          Single-moment evaluation — no solver
+        </span>
+      </div>
+
+      {/* Three-panel layout */}
+      <div className="flex gap-6">
+        {/* Left: Scenario Panel */}
+        <div className="w-64 flex-shrink-0">
+          <ValidatorScenarioPanel
+            scenarios={scenarios}
+            selectedId={selectedId}
+            onSelect={handleSelectScenario}
+            onReset={handleReset}
+            isDirty={isDirty}
+          />
+        </div>
+
+        {/* Center: Grid */}
+        <div className="flex-shrink-0">
+          <ValidatorGrid
+            layout={layout}
+            padFingerAssignment={assignment}
+            moment={moment}
+            violatedPads={violatedPads}
+            onMovePad={handleMovePad}
+            onReassignFinger={handleReassignFinger}
+          />
+        </div>
+
+        {/* Right: Results Panel */}
+        <div className="flex-1 min-w-[280px] max-w-[360px]">
+          <ValidatorResultsPanel result={result} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/pages/ProjectLibraryPage.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/pages/ProjectLibraryPage.tsx
@@ -9,7 +9,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { type ProjectState, type SoundStream, type SoundEvent, createEmptyProjectState } from '../state/projectState';
-import { listProjects, saveProject, deleteProject, removeFromIndex, clearProjectIndex, importProjectFromFile, type ProjectLibraryEntry } from '../persistence/projectStorage';
+import { listProjects, saveProject, deleteProject, removeFromIndex, clearProjectIndex, type ProjectLibraryEntry } from '../persistence/projectStorage';
 import { getDemoProjects, createDemoCopy } from '../fixtures/demoProjects';
 import { parseMidiFileToProject } from '../../import/midiImport';
 import { analyzePerformance } from '../../engine/structure/performanceAnalyzer';
@@ -54,16 +54,13 @@ export function ProjectLibraryPage() {
 
   const demoGroups = useMemo(() => {
     const generic: ProjectState[] = [];
-    const atomicTests: ProjectState[] = [];
     const temporalTests: ProjectState[] = [];
     for (const demo of demoProjects) {
-      if (demo.id.startsWith('feasibility-a')) atomicTests.push(demo);
-      else if (demo.id.startsWith('feasibility-f')) temporalTests.push(demo);
+      if (demo.id.startsWith('feasibility-f')) temporalTests.push(demo);
       else generic.push(demo);
     }
     return [
       { key: 'generic', label: 'Basic Demos', demos: generic },
-      { key: 'atomic', label: 'A1–A8: Atomic Constraints', demos: atomicTests },
       { key: 'temporal', label: 'F1–F6: Temporal Sequences', demos: temporalTests },
     ];
   }, [demoProjects]);
@@ -239,19 +236,6 @@ export function ProjectLibraryPage() {
     setSavedProjects([]);
   }, []);
 
-  const handleImportJSON = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    const result = await importProjectFromFile(file);
-    if (result.ok) {
-      saveProject(result.state);
-      setSavedProjects(listProjects());
-      navigate(`/project/${result.state.id}`);
-    } else {
-      setError(result.error);
-    }
-  }, [navigate]);
-
   // ---- Render ----
 
   if (step === 'naming' && pendingImport) {
@@ -369,15 +353,12 @@ export function ProjectLibraryPage() {
         >
           + New Project
         </button>
-        <label className="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded text-sm text-gray-400 cursor-pointer border border-gray-700">
-          Import Project JSON
-          <input
-            type="file"
-            accept=".json,.pushflow.json"
-            className="hidden"
-            onChange={handleImportJSON}
-          />
-        </label>
+        <button
+          className="px-3 py-1.5 bg-purple-600/80 hover:bg-purple-500/80 rounded text-sm font-medium text-white transition-colors"
+          onClick={() => navigate('/validator')}
+        >
+          Constraint Validator
+        </button>
       </div>
 
       {error && (

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorGrid.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorGrid.tsx
@@ -1,0 +1,271 @@
+/**
+ * Validator Grid (center panel).
+ *
+ * 8x8 pad grid with voice labels, finger ownership indicators,
+ * drag-to-move pads, and click-to-reassign fingers.
+ * Operates on local state only — no ProjectContext dependency.
+ */
+
+import { useState, useMemo, useCallback } from 'react';
+import { type Layout } from '../../types/layout';
+import { type Voice } from '../../types/voice';
+import { type PadFingerAssignment } from '../../types/executionPlan';
+import { type PerformanceMoment } from '../../types/performanceEvent';
+import { type FingerType } from '../../types/fingerModel';
+import { padKey, parsePadKey } from '../../types/padGrid';
+
+const ROWS = 8;
+const COLS = 8;
+
+const HAND_COLORS = {
+  left: { bg: 'bg-blue-500/20', border: 'border-blue-500/40', text: 'text-blue-300' },
+  right: { bg: 'bg-purple-500/20', border: 'border-purple-500/40', text: 'text-purple-300' },
+};
+
+const FINGER_LABELS: Record<FingerType, string> = {
+  thumb: 'Th',
+  index: 'Ix',
+  middle: 'Md',
+  ring: 'Rn',
+  pinky: 'Pk',
+};
+
+const ALL_FINGERS: FingerType[] = ['thumb', 'index', 'middle', 'ring', 'pinky'];
+
+interface Props {
+  layout: Layout;
+  padFingerAssignment: PadFingerAssignment;
+  moment: PerformanceMoment;
+  violatedPads: Set<string>;
+  onMovePad: (fromPadKey: string, toRow: number, toCol: number) => void;
+  onReassignFinger: (padKey: string, hand: 'left' | 'right', finger: FingerType) => void;
+}
+
+export function ValidatorGrid({
+  layout,
+  padFingerAssignment,
+  moment,
+  violatedPads,
+  onMovePad,
+  onReassignFinger,
+}: Props) {
+  const [dragSource, setDragSource] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+  const [editingPad, setEditingPad] = useState<string | null>(null);
+
+  // Build set of active pads from moment
+  const activePads = useMemo(() => {
+    const set = new Set<string>();
+    for (const note of moment.notes) {
+      if (note.padId) set.add(note.padId);
+    }
+    return set;
+  }, [moment]);
+
+  const handleDragStart = useCallback((pk: string) => {
+    setDragSource(pk);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, pk: string) => {
+    e.preventDefault();
+    setDragOver(pk);
+  }, []);
+
+  const handleDrop = useCallback(
+    (targetRow: number, targetCol: number) => {
+      if (dragSource) {
+        const targetKey = padKey(targetRow, targetCol);
+        if (targetKey !== dragSource && !layout.padToVoice[targetKey]) {
+          onMovePad(dragSource, targetRow, targetCol);
+        }
+      }
+      setDragSource(null);
+      setDragOver(null);
+    },
+    [dragSource, layout.padToVoice, onMovePad],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDragSource(null);
+    setDragOver(null);
+  }, []);
+
+  const handlePadClick = useCallback((pk: string) => {
+    setEditingPad(prev => (prev === pk ? null : pk));
+  }, []);
+
+  // Render grid rows top-to-bottom (row 7 at top, row 0 at bottom)
+  const rows = [];
+  for (let row = ROWS - 1; row >= 0; row--) {
+    const cells = [];
+    for (let col = 0; col < COLS; col++) {
+      const pk = padKey(row, col);
+      const voice = layout.padToVoice[pk] as Voice | undefined;
+      const owner = padFingerAssignment[pk];
+      const isActive = activePads.has(pk);
+      const isViolated = violatedPads.has(pk);
+      const isDragSource = dragSource === pk;
+      const isDragTarget = dragOver === pk;
+
+      cells.push(
+        <div
+          key={pk}
+          className={`
+            relative w-14 h-14 rounded border text-center flex flex-col items-center justify-center
+            transition-all duration-100 select-none
+            ${voice
+              ? owner
+                ? `${HAND_COLORS[owner.hand].bg} ${HAND_COLORS[owner.hand].border}`
+                : 'bg-gray-700/50 border-gray-500/40'
+              : 'bg-gray-900/30 border-gray-800/40'}
+            ${isActive ? 'ring-1 ring-yellow-400/50' : ''}
+            ${isViolated ? 'ring-2 ring-red-500/80' : ''}
+            ${isDragSource ? 'opacity-30' : ''}
+            ${isDragTarget ? 'ring-2 ring-blue-400' : ''}
+            ${voice ? 'cursor-pointer' : ''}
+          `}
+          draggable={!!voice}
+          onDragStart={() => voice && handleDragStart(pk)}
+          onDragOver={e => handleDragOver(e, pk)}
+          onDrop={() => handleDrop(row, col)}
+          onDragEnd={handleDragEnd}
+          onClick={() => voice && handlePadClick(pk)}
+        >
+          {/* Voice label */}
+          {voice && (
+            <span className="text-[8px] text-gray-300 truncate w-full px-0.5 leading-tight">
+              {voice.name.length > 8 ? voice.name.slice(0, 7) + '…' : voice.name}
+            </span>
+          )}
+
+          {/* Finger label */}
+          {owner && (
+            <span className={`text-[9px] font-mono ${HAND_COLORS[owner.hand].text}`}>
+              {owner.hand === 'left' ? 'L' : 'R'}-{FINGER_LABELS[owner.finger]}
+            </span>
+          )}
+
+          {/* Active indicator */}
+          {isActive && !voice && (
+            <span className="text-[8px] text-yellow-500">?</span>
+          )}
+
+          {/* Pad coordinate (bottom) */}
+          <span className="absolute bottom-0 right-0.5 text-[7px] text-gray-600">
+            {row},{col}
+          </span>
+        </div>,
+      );
+    }
+    rows.push(
+      <div key={row} className="flex gap-1">
+        {cells}
+      </div>,
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      {/* Grid */}
+      <div className="flex flex-col gap-1">{rows}</div>
+
+      {/* Finger reassignment popover */}
+      {editingPad && padFingerAssignment[editingPad] && (
+        <FingerPicker
+          padKey={editingPad}
+          currentHand={padFingerAssignment[editingPad].hand}
+          currentFinger={padFingerAssignment[editingPad].finger}
+          onSelect={(hand, finger) => {
+            onReassignFinger(editingPad, hand, finger);
+            setEditingPad(null);
+          }}
+          onClose={() => setEditingPad(null)}
+        />
+      )}
+
+      {/* Assign finger to unassigned pad */}
+      {editingPad && !padFingerAssignment[editingPad] && layout.padToVoice[editingPad] && (
+        <FingerPicker
+          padKey={editingPad}
+          currentHand="right"
+          currentFinger="index"
+          onSelect={(hand, finger) => {
+            onReassignFinger(editingPad, hand, finger);
+            setEditingPad(null);
+          }}
+          onClose={() => setEditingPad(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Finger Picker Sub-component
+// ============================================================================
+
+function FingerPicker({
+  padKey: pk,
+  currentHand,
+  currentFinger,
+  onSelect,
+  onClose,
+}: {
+  padKey: string;
+  currentHand: 'left' | 'right';
+  currentFinger: FingerType;
+  onSelect: (hand: 'left' | 'right', finger: FingerType) => void;
+  onClose: () => void;
+}) {
+  const [hand, setHand] = useState(currentHand);
+  const coord = parsePadKey(pk);
+
+  return (
+    <div className="mt-2 p-3 bg-gray-800 border border-gray-600 rounded-lg">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs text-gray-400">
+          Reassign finger for pad {coord ? `(${coord.row},${coord.col})` : pk}
+        </span>
+        <button onClick={onClose} className="text-gray-500 hover:text-gray-300 text-xs">
+          ✕
+        </button>
+      </div>
+
+      {/* Hand toggle */}
+      <div className="flex gap-1 mb-2">
+        {(['left', 'right'] as const).map(h => (
+          <button
+            key={h}
+            onClick={() => setHand(h)}
+            className={`flex-1 text-xs px-2 py-1 rounded transition-colors ${
+              hand === h
+                ? h === 'left'
+                  ? 'bg-blue-500/30 text-blue-300 border border-blue-500/50'
+                  : 'bg-purple-500/30 text-purple-300 border border-purple-500/50'
+                : 'bg-gray-700 text-gray-400 border border-gray-600'
+            }`}
+          >
+            {h}
+          </button>
+        ))}
+      </div>
+
+      {/* Finger buttons */}
+      <div className="flex gap-1">
+        {ALL_FINGERS.map(f => (
+          <button
+            key={f}
+            onClick={() => onSelect(hand, f)}
+            className={`flex-1 text-[10px] px-1 py-1.5 rounded transition-colors ${
+              hand === currentHand && f === currentFinger
+                ? 'bg-yellow-500/30 text-yellow-300 border border-yellow-500/50'
+                : 'bg-gray-700 text-gray-400 border border-gray-600 hover:bg-gray-600'
+            }`}
+          >
+            {FINGER_LABELS[f]}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorResultsPanel.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorResultsPanel.tsx
@@ -1,0 +1,254 @@
+/**
+ * Validator Results Panel (right panel).
+ *
+ * Shows status badge, feasibility tier, CostDimensions table,
+ * evidence cards, assignment issues, and debug info.
+ */
+
+import { type ValidatorResult, type ConstraintViolationEvidence } from './types';
+import { type CostDimensions } from '../../types/costBreakdown';
+
+interface Props {
+  result: ValidatorResult | null;
+}
+
+export function ValidatorResultsPanel({ result }: Props) {
+  if (!result) {
+    return (
+      <div className="flex items-center justify-center h-32 text-gray-500 text-sm">
+        Select a scenario to see results
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Status Badge */}
+      <StatusBadge status={result.status} tier={result.feasibilityTier} />
+
+      {/* Cost Dimensions */}
+      <CostDimensionsTable dimensions={result.dimensions} />
+
+      {/* Pose Detail */}
+      <PoseDetailSection
+        attractor={result.poseDetail.attractor}
+        perFingerHome={result.poseDetail.perFingerHome}
+        fingerDominance={result.poseDetail.fingerDominance}
+      />
+
+      {/* Evidence Cards */}
+      {result.evidence.length > 0 && (
+        <EvidenceSection evidence={result.evidence} />
+      )}
+
+      {/* Assignment Issues */}
+      {!result.assignmentValidation.valid && (
+        <AssignmentIssuesSection issues={result.assignmentValidation.issues} />
+      )}
+
+      {/* Grip Rejections Debug */}
+      {result.gripRejections.length > 0 && (
+        <GripRejectionsSection rejections={result.gripRejections} />
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function StatusBadge({
+  status,
+  tier,
+}: {
+  status: 'valid' | 'violation';
+  tier: string;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className={`text-sm font-semibold px-3 py-1.5 rounded-full ${
+          status === 'valid'
+            ? 'bg-green-500/20 text-green-300 border border-green-500/30'
+            : 'bg-red-500/20 text-red-300 border border-red-500/30'
+        }`}
+      >
+        {status === 'valid' ? 'Valid' : 'Violation'}
+      </span>
+      <span className="text-[10px] text-gray-500 uppercase tracking-wider">
+        tier: {tier}
+      </span>
+    </div>
+  );
+}
+
+function CostDimensionsTable({ dimensions }: { dimensions: CostDimensions }) {
+  const rows: Array<{ label: string; key: keyof CostDimensions }> = [
+    { label: 'Pose Naturalness', key: 'poseNaturalness' },
+    { label: 'Transition Cost', key: 'transitionCost' },
+    { label: 'Constraint Penalty', key: 'constraintPenalty' },
+    { label: 'Alternation', key: 'alternation' },
+    { label: 'Hand Balance', key: 'handBalance' },
+    { label: 'Total', key: 'total' },
+  ];
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+        Cost Dimensions
+      </h3>
+      <div className="bg-gray-800/50 rounded border border-gray-700/50">
+        {rows.map(({ label, key }) => (
+          <div
+            key={key}
+            className={`flex justify-between px-3 py-1.5 text-xs ${
+              key === 'total' ? 'border-t border-gray-600/50 font-semibold text-gray-200' : 'text-gray-400'
+            }`}
+          >
+            <span>{label}</span>
+            <span className="font-mono tabular-nums">
+              {dimensions[key].toFixed(4)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PoseDetailSection({
+  attractor,
+  perFingerHome,
+  fingerDominance,
+}: {
+  attractor: number;
+  perFingerHome: number;
+  fingerDominance: number;
+}) {
+  const items = [
+    { label: 'Attractor', value: attractor },
+    { label: 'Per-Finger Home', value: perFingerHome },
+    { label: 'Finger Preference', value: fingerDominance },
+  ];
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+        Pose Detail
+      </h3>
+      <div className="bg-gray-800/50 rounded border border-gray-700/50">
+        {items.map(({ label, value }) => (
+          <div key={label} className="flex justify-between px-3 py-1.5 text-xs text-gray-400">
+            <span>{label}</span>
+            <span className="font-mono tabular-nums">{value.toFixed(4)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EvidenceSection({ evidence }: { evidence: ConstraintViolationEvidence[] }) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+        Violations ({evidence.length})
+      </h3>
+      <div className="flex flex-col gap-2">
+        {evidence.map((e, i) => (
+          <EvidenceCard key={i} evidence={e} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EvidenceCard({ evidence }: { evidence: ConstraintViolationEvidence }) {
+  return (
+    <div className="bg-red-500/10 border border-red-500/20 rounded p-2.5">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-300 font-mono">
+          {evidence.constraintId}
+        </span>
+        <span className="text-[10px] text-gray-500 uppercase">
+          {evidence.severity}
+        </span>
+      </div>
+      <p className="text-xs text-gray-300 leading-relaxed">{evidence.message}</p>
+      {(evidence.measuredValue !== undefined || evidence.threshold !== undefined) && (
+        <div className="flex gap-3 mt-1.5 text-[10px] text-gray-500">
+          {evidence.measuredValue !== undefined && (
+            <span>measured: <span className="text-red-300 font-mono">{evidence.measuredValue.toFixed(2)}</span></span>
+          )}
+          {evidence.threshold !== undefined && (
+            <span>limit: <span className="text-gray-400 font-mono">{evidence.threshold.toFixed(2)}</span></span>
+          )}
+        </div>
+      )}
+      {evidence.pads && (
+        <div className="mt-1 text-[10px] text-gray-500">
+          pads: {evidence.pads.join(', ')}
+        </div>
+      )}
+      {evidence.fingers && (
+        <div className="text-[10px] text-gray-500">
+          fingers: {evidence.fingers.join(', ')}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AssignmentIssuesSection({
+  issues,
+}: {
+  issues: Array<{ type: string; message: string; padKey?: string }>;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+        Assignment Issues ({issues.length})
+      </h3>
+      <div className="flex flex-col gap-1.5">
+        {issues.map((issue, i) => (
+          <div
+            key={i}
+            className="bg-amber-500/10 border border-amber-500/20 rounded px-2.5 py-2 text-xs text-amber-300"
+          >
+            <span className="font-mono text-[10px] text-amber-400">[{issue.type}]</span>{' '}
+            {issue.message}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GripRejectionsSection({
+  rejections,
+}: {
+  rejections: Array<{ fingerA: string; fingerB: string; rule: string; actual: number; limit: number }>;
+}) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">
+        Grip Rejections (debug)
+      </h3>
+      <div className="bg-gray-800/50 rounded border border-gray-700/50 max-h-32 overflow-y-auto">
+        {rejections.slice(0, 20).map((r, i) => (
+          <div key={i} className="flex gap-2 px-2.5 py-1 text-[10px] text-gray-500 border-b border-gray-700/30 last:border-b-0">
+            <span className="font-mono text-gray-400">{r.rule}</span>
+            <span>{r.fingerA}↔{r.fingerB}</span>
+            <span className="ml-auto font-mono">{r.actual.toFixed(2)} / {r.limit.toFixed(1)}</span>
+          </div>
+        ))}
+        {rejections.length > 20 && (
+          <div className="px-2.5 py-1 text-[10px] text-gray-600">
+            +{rejections.length - 20} more...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorScenarioPanel.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/ValidatorScenarioPanel.tsx
@@ -1,0 +1,94 @@
+/**
+ * Validator Scenario Panel (left panel).
+ *
+ * Dropdown to select a scenario, description text, constraint tags,
+ * and a reset button.
+ */
+
+import { type ValidatorScenario } from './types';
+
+interface Props {
+  scenarios: ValidatorScenario[];
+  selectedId: string;
+  onSelect: (id: string) => void;
+  onReset: () => void;
+  isDirty: boolean;
+}
+
+export function ValidatorScenarioPanel({
+  scenarios,
+  selectedId,
+  onSelect,
+  onReset,
+  isDirty,
+}: Props) {
+  const selected = scenarios.find(s => s.id === selectedId);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider">
+        Scenario
+      </h2>
+
+      {/* Dropdown */}
+      <select
+        value={selectedId}
+        onChange={e => onSelect(e.target.value)}
+        className="w-full bg-gray-800 border border-gray-600 rounded px-3 py-2 text-sm text-gray-200 focus:outline-none focus:border-blue-500"
+      >
+        {scenarios.map(s => (
+          <option key={s.id} value={s.id}>
+            {s.id}: {s.title}
+          </option>
+        ))}
+      </select>
+
+      {/* Description */}
+      {selected && (
+        <div className="text-xs text-gray-400 leading-relaxed">
+          {selected.description}
+        </div>
+      )}
+
+      {/* Constraint Tags */}
+      {selected && (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.constraintIds.map(c => (
+            <span
+              key={c}
+              className="text-[10px] px-2 py-0.5 rounded-full bg-purple-500/20 text-purple-300 border border-purple-500/30"
+            >
+              {c}
+            </span>
+          ))}
+          <span
+            className={`text-[10px] px-2 py-0.5 rounded-full border ${
+              selected.expectedInitialStatus === 'violation'
+                ? 'bg-red-500/20 text-red-300 border-red-500/30'
+                : 'bg-green-500/20 text-green-300 border-green-500/30'
+            }`}
+          >
+            expects: {selected.expectedInitialStatus}
+          </span>
+        </div>
+      )}
+
+      {/* Fix hint */}
+      {selected?.fixHint && (
+        <div className="text-[10px] text-amber-400/80 bg-amber-500/10 border border-amber-500/20 rounded px-2 py-1.5 leading-relaxed">
+          {selected.fixHint}
+        </div>
+      )}
+
+      {/* Reset button */}
+      {isDirty && (
+        <button
+          onClick={onReset}
+          className="w-full bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs px-3 py-2 rounded transition-colors"
+        >
+          Reset to Original
+        </button>
+      )}
+    </div>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/types.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/types.ts
@@ -1,0 +1,131 @@
+/**
+ * Atomic Constraint Validator Types.
+ *
+ * Types for the dedicated single-moment constraint validation harness.
+ * This validator calls evaluateEvent() and validateAssignment() directly —
+ * no solver involvement.
+ */
+
+import { type Layout } from '../../types/layout';
+import { type PadFingerAssignment } from '../../types/executionPlan';
+import { type PerformanceMoment } from '../../types/performanceEvent';
+import { type ConstraintRuleName, type GripRejection } from '../../engine/prior/biomechanicalModel';
+import { type ConstraintTier } from '../../engine/prior/feasibility';
+import {
+  type CostDimensions,
+  type EventCostBreakdown,
+  type AssignmentValidationResult,
+  type PoseNaturalnessDetail,
+} from '../../types/costBreakdown';
+
+// ============================================================================
+// Scenario Definition
+// ============================================================================
+
+/**
+ * A single pre-built validator scenario.
+ *
+ * Each scenario provides a fixed layout, finger assignment, and moment
+ * that demonstrates a specific constraint violation (or valid state).
+ */
+export interface ValidatorScenario {
+  /** Unique scenario ID (e.g., 'V1', 'V2'). */
+  id: string;
+  /** Human-readable title. */
+  title: string;
+  /** Explanation of what this scenario demonstrates. */
+  description: string;
+  /** Which biomechanical rules this scenario tests. */
+  constraintIds: ConstraintRuleName[];
+  /** Single moment with all notes occurring simultaneously. */
+  moment: PerformanceMoment;
+  /** Layout with pad-to-voice mapping. */
+  layout: Layout;
+  /** Pre-built finger assignment (may demonstrate a violation). */
+  padFingerAssignment: PadFingerAssignment;
+  /** Whether the scenario should be valid or violating on load. */
+  expectedInitialStatus: 'valid' | 'violation';
+  /** Optional hint for how to fix or break the scenario by dragging. */
+  fixHint?: string;
+}
+
+// ============================================================================
+// Evidence
+// ============================================================================
+
+/**
+ * Structured evidence for a specific constraint violation.
+ *
+ * Every violation produces one or more evidence items with enough detail
+ * to understand exactly what failed and why.
+ */
+export interface ConstraintViolationEvidence {
+  /** Which constraint rule was violated. */
+  constraintId: ConstraintRuleName | 'unmapped_note' | 'ownership_conflict' | 'missing_assignment';
+  /** Hard = infeasible, soft = degraded but feasible. */
+  severity: 'hard' | 'soft';
+  /** Human-readable explanation. */
+  message: string;
+  /** Pad keys involved. */
+  pads?: string[];
+  /** MIDI note numbers involved. */
+  notes?: number[];
+  /** Finger names involved. */
+  fingers?: string[];
+  /** Hand involved. */
+  hand?: 'left' | 'right';
+  /** Measured value (e.g., distance between fingers). */
+  measuredValue?: number;
+  /** Threshold that was exceeded. */
+  threshold?: number;
+  /** Feasibility tier context. */
+  tier?: ConstraintTier;
+  /** Additional debug data. */
+  debug?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Validation Result
+// ============================================================================
+
+/**
+ * Complete validation result assembled by the validator engine.
+ */
+export interface ValidatorResult {
+  /** Overall status: valid or violation. */
+  status: 'valid' | 'violation';
+  /** Feasibility tier from evaluateEvent ('strict' in V1). */
+  feasibilityTier: ConstraintTier;
+  /** Full 5-dimension cost vector. */
+  dimensions: CostDimensions;
+  /** Pose sub-breakdown (attractor, perFingerHome, fingerDominance). */
+  poseDetail: PoseNaturalnessDetail;
+  /** Full EventCostBreakdown from evaluateEvent. */
+  eventBreakdown: EventCostBreakdown | null;
+  /** validateAssignment result. */
+  assignmentValidation: AssignmentValidationResult;
+  /** Extracted violation evidence. */
+  evidence: ConstraintViolationEvidence[];
+  /** Raw grip rejections from feasibility diagnostic mode. */
+  gripRejections: GripRejection[];
+}
+
+// ============================================================================
+// Page State
+// ============================================================================
+
+/**
+ * Mutable state for the validator page.
+ */
+export interface ValidatorState {
+  /** Currently selected scenario ID. */
+  selectedScenarioId: string;
+  /** Current layout (may be edited by user). */
+  layout: Layout;
+  /** Current finger assignment (may be edited by user). */
+  padFingerAssignment: PadFingerAssignment;
+  /** Current moment (padIds updated when layout changes). */
+  moment: PerformanceMoment;
+  /** Latest validation result (null before first evaluation). */
+  result: ValidatorResult | null;
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/validatorEngine.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/validatorEngine.ts
@@ -1,0 +1,492 @@
+/**
+ * Validator Engine Bridge.
+ *
+ * Connects the validator UI to the canonical evaluator and feasibility checker.
+ * Builds EvaluationConfig, calls evaluateEvent/validateAssignment, extracts
+ * grip diagnostic evidence, and runs direct pairwise constraint checks.
+ *
+ * No solver dependency — pure evaluation only.
+ */
+
+import { type Layout } from '../../types/layout';
+import { type PadFingerAssignment } from '../../types/executionPlan';
+import { type PerformanceMoment } from '../../types/performanceEvent';
+import { type EvaluationConfig } from '../../types/evaluationConfig';
+import { type InstrumentConfig, type RestingPose } from '../../types/performance';
+import { type FingerType } from '../../types/fingerModel';
+import { type PadCoord, parsePadKey } from '../../types/padGrid';
+import { createZeroCostDimensions } from '../../types/costBreakdown';
+import {
+  evaluateEvent,
+  validateAssignment,
+} from '../../engine/evaluation/canonicalEvaluator';
+import {
+  generateValidGrips,
+  type GripDiagnosticOptions,
+} from '../../engine/prior/feasibility';
+import {
+  type GripRejection,
+  type ConstraintRuleName,
+  FINGER_PAIR_MAX_SPAN_STRICT,
+  THUMB_DELTA,
+  FINGER_ORDER,
+} from '../../engine/prior/biomechanicalModel';
+import {
+  resolveNeutralPadPositions,
+  computeNeutralHandCenters,
+} from '../../engine/prior/handPose';
+import {
+  type ValidatorResult,
+  type ConstraintViolationEvidence,
+} from './types';
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+const VALIDATOR_INSTRUMENT_CONFIG: InstrumentConfig = {
+  id: 'validator',
+  name: 'Push 3',
+  rows: 8,
+  cols: 8,
+  bottomLeftNote: 36,
+  layoutMode: 'drum_64',
+};
+
+const VALIDATOR_RESTING_POSE: RestingPose = {
+  left: {
+    centroid: { x: 2, y: 2 },
+    fingers: {
+      thumb: { x: 1, y: 1 },
+      index: { x: 2, y: 2 },
+      middle: { x: 3, y: 3 },
+    },
+  },
+  right: {
+    centroid: { x: 5, y: 2 },
+    fingers: {
+      thumb: { x: 6, y: 1 },
+      index: { x: 5, y: 2 },
+      middle: { x: 4, y: 3 },
+    },
+  },
+};
+
+/**
+ * Build an EvaluationConfig for the validator.
+ * Uses the same pattern as test/engine/evaluation/canonicalEvaluator.test.ts.
+ */
+export function buildEvaluationConfig(layout: Layout): EvaluationConfig {
+  const neutralPads = resolveNeutralPadPositions(layout, VALIDATOR_INSTRUMENT_CONFIG);
+  const neutralHandCenters = computeNeutralHandCenters(neutralPads);
+  return {
+    restingPose: VALIDATOR_RESTING_POSE,
+    stiffness: 0.3,
+    instrumentConfig: VALIDATOR_INSTRUMENT_CONFIG,
+    neutralHandCenters,
+  };
+}
+
+// ============================================================================
+// Pairwise Key Helper
+// ============================================================================
+
+function pairKey(a: FingerType, b: FingerType): string {
+  // Keys in FINGER_PAIR_MAX_SPAN_STRICT are alphabetically sorted
+  const ordered = [a, b].sort();
+  return `${ordered[0]},${ordered[1]}`;
+}
+
+function fingerDistance(a: PadCoord, b: PadCoord): number {
+  const dx = b.col - a.col;
+  const dy = b.row - a.row;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+// ============================================================================
+// Direct Pairwise Constraint Checks
+// ============================================================================
+
+/**
+ * Run direct constraint checks against the user's exact finger assignment.
+ *
+ * The grip generator permutes all finger combinations, so some violations
+ * specific to the user's exact assignment may not appear in grip diagnostics.
+ * These direct checks catch those cases.
+ */
+function runDirectConstraintChecks(
+  padFingerAssignment: PadFingerAssignment,
+  activePadKeys: string[],
+): ConstraintViolationEvidence[] {
+  const evidence: ConstraintViolationEvidence[] = [];
+
+  // Group active pads by hand
+  const leftFingers: Array<{ finger: FingerType; coord: PadCoord; padKey: string }> = [];
+  const rightFingers: Array<{ finger: FingerType; coord: PadCoord; padKey: string }> = [];
+
+  for (const pk of activePadKeys) {
+    const owner = padFingerAssignment[pk];
+    if (!owner) continue;
+    const coord = parsePadKey(pk);
+    if (!coord) continue;
+    const entry = { finger: owner.finger, coord, padKey: pk };
+    if (owner.hand === 'left') leftFingers.push(entry);
+    else rightFingers.push(entry);
+  }
+
+  // Check for same-finger collision (same finger assigned to 2+ active pads)
+  const checkSameFingerCollision = (
+    entries: typeof leftFingers,
+    hand: 'left' | 'right',
+  ) => {
+    const fingerToPads = new Map<FingerType, string[]>();
+    for (const e of entries) {
+      const list = fingerToPads.get(e.finger) ?? [];
+      list.push(e.padKey);
+      fingerToPads.set(e.finger, list);
+    }
+    for (const [finger, pads] of fingerToPads) {
+      if (pads.length > 1) {
+        evidence.push({
+          constraintId: 'collision',
+          severity: 'hard',
+          message: `${hand} ${finger} is assigned to ${pads.length} simultaneously active pads: ${pads.join(', ')}`,
+          pads,
+          fingers: [finger],
+          hand,
+        });
+      }
+    }
+  };
+  checkSameFingerCollision(leftFingers, 'left');
+  checkSameFingerCollision(rightFingers, 'right');
+
+  // Check pairwise span constraints
+  const checkPairwiseSpan = (
+    entries: typeof leftFingers,
+    hand: 'left' | 'right',
+  ) => {
+    for (let i = 0; i < entries.length; i++) {
+      for (let j = i + 1; j < entries.length; j++) {
+        const a = entries[i];
+        const b = entries[j];
+        const key = pairKey(a.finger, b.finger);
+        const maxSpan = FINGER_PAIR_MAX_SPAN_STRICT[key] ?? 5.5;
+        const dist = fingerDistance(a.coord, b.coord);
+        if (dist > maxSpan) {
+          evidence.push({
+            constraintId: 'span',
+            severity: 'hard',
+            message: `${hand} ${a.finger} ↔ ${b.finger} distance = ${dist.toFixed(2)}, max = ${maxSpan.toFixed(1)}`,
+            pads: [a.padKey, b.padKey],
+            fingers: [a.finger, b.finger],
+            hand,
+            measuredValue: dist,
+            threshold: maxSpan,
+          });
+        }
+      }
+    }
+  };
+  checkPairwiseSpan(leftFingers, 'left');
+  checkPairwiseSpan(rightFingers, 'right');
+
+  // Check finger ordering (topology)
+  const checkOrdering = (
+    entries: typeof leftFingers,
+    hand: 'left' | 'right',
+  ) => {
+    const nonThumb = entries.filter(e => e.finger !== 'thumb');
+    const sorted = [...nonThumb].sort(
+      (a, b) => FINGER_ORDER.indexOf(a.finger) - FINGER_ORDER.indexOf(b.finger),
+    );
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const a = sorted[i];
+      const b = sorted[i + 1];
+      // FINGER_ORDER = [pinky, ring, middle, index, thumb]
+      // a comes earlier in FINGER_ORDER, b comes later
+      if (hand === 'right') {
+        // Right hand: pinky is rightmost (highest col), index is leftmost
+        // Going pinky→ring→middle→index: columns should DECREASE
+        // Violation when a.col <= b.col (a should be right of b)
+        if (a.coord.col <= b.coord.col) {
+          evidence.push({
+            constraintId: 'ordering',
+            severity: 'hard',
+            message: `${hand} hand ordering violation: ${a.finger}(col ${a.coord.col}) should be right of ${b.finger}(col ${b.coord.col})`,
+            pads: [a.padKey, b.padKey],
+            fingers: [a.finger, b.finger],
+            hand,
+            measuredValue: a.coord.col,
+            threshold: b.coord.col,
+          });
+        }
+      } else {
+        // Left hand: pinky is leftmost (lowest col), index is rightmost
+        // Going pinky→ring→middle→index: columns should INCREASE
+        // Violation when a.col >= b.col (a should be left of b)
+        if (a.coord.col >= b.coord.col) {
+          evidence.push({
+            constraintId: 'ordering',
+            severity: 'hard',
+            message: `${hand} hand ordering violation: ${a.finger}(col ${a.coord.col}) should be left of ${b.finger}(col ${b.coord.col})`,
+            pads: [a.padKey, b.padKey],
+            fingers: [a.finger, b.finger],
+            hand,
+            measuredValue: a.coord.col,
+            threshold: b.coord.col,
+          });
+        }
+      }
+    }
+  };
+  checkOrdering(leftFingers, 'left');
+  checkOrdering(rightFingers, 'right');
+
+  // Check thumb delta
+  const checkThumbDelta = (
+    entries: typeof leftFingers,
+    hand: 'left' | 'right',
+  ) => {
+    const thumbEntry = entries.find(e => e.finger === 'thumb');
+    if (!thumbEntry) return;
+    for (const other of entries) {
+      if (other.finger === 'thumb') continue;
+      const delta = thumbEntry.coord.row - other.coord.row;
+      if (delta > THUMB_DELTA) {
+        evidence.push({
+          constraintId: 'thumbDelta',
+          severity: 'hard',
+          message: `${hand} thumb row offset = ${delta.toFixed(1)}, max = ${THUMB_DELTA.toFixed(1)} (thumb row ${thumbEntry.coord.row}, ${other.finger} row ${other.coord.row})`,
+          pads: [thumbEntry.padKey, other.padKey],
+          fingers: ['thumb', other.finger],
+          hand,
+          measuredValue: delta,
+          threshold: THUMB_DELTA,
+        });
+      }
+    }
+  };
+  checkThumbDelta(leftFingers, 'left');
+  checkThumbDelta(rightFingers, 'right');
+
+  return evidence;
+}
+
+// ============================================================================
+// Grip Evidence Extraction
+// ============================================================================
+
+/**
+ * Extract grip diagnostic rejections by running generateValidGrips in
+ * diagnostic mode for each hand's active pads.
+ *
+ * Only returns rejections for hands where NO valid grips exist (infeasible).
+ * When valid grips exist, the rejections are for failed permutations during
+ * enumeration and are noise — the hand configuration IS feasible.
+ */
+function extractGripEvidence(
+  padFingerAssignment: PadFingerAssignment,
+  activePadKeys: string[],
+): GripRejection[] {
+  const leftPads: PadCoord[] = [];
+  const rightPads: PadCoord[] = [];
+
+  for (const pk of activePadKeys) {
+    const owner = padFingerAssignment[pk];
+    if (!owner) continue;
+    const coord = parsePadKey(pk);
+    if (!coord) continue;
+    if (owner.hand === 'left') leftPads.push(coord);
+    else rightPads.push(coord);
+  }
+
+  const allRejections: GripRejection[] = [];
+
+  if (leftPads.length > 0) {
+    const diagnostics: GripDiagnosticOptions = { enabled: true, rejections: [] };
+    const validGrips = generateValidGrips(leftPads, 'left', diagnostics);
+    // Only report rejections if no valid grip exists (infeasible)
+    if (validGrips.length === 0) {
+      allRejections.push(...diagnostics.rejections);
+    }
+  }
+
+  if (rightPads.length > 0) {
+    const diagnostics: GripDiagnosticOptions = { enabled: true, rejections: [] };
+    const validGrips = generateValidGrips(rightPads, 'right', diagnostics);
+    if (validGrips.length === 0) {
+      allRejections.push(...diagnostics.rejections);
+    }
+  }
+
+  return allRejections;
+}
+
+/**
+ * Convert GripRejection to ConstraintViolationEvidence.
+ */
+function gripRejectionToEvidence(r: GripRejection): ConstraintViolationEvidence {
+  const ruleMessages: Record<ConstraintRuleName, string> = {
+    span: `Span violation: ${r.fingerA} ↔ ${r.fingerB} distance ${r.actual.toFixed(2)} > limit ${r.limit.toFixed(1)}`,
+    ordering: `Ordering violation: ${r.fingerA} / ${r.fingerB} crossover (delta ${r.actual.toFixed(2)})`,
+    collision: `Collision: ${r.fingerA} and ${r.fingerB} on same pad`,
+    thumbDelta: `Thumb delta: ${r.fingerA} / ${r.fingerB} row offset ${r.actual.toFixed(1)} > limit ${r.limit.toFixed(1)}`,
+    topology: `Topology violation: ${r.fingerA} / ${r.fingerB} hand shape invalid`,
+    reachability: `Reachability: ${r.fingerA} / ${r.fingerB} distance ${r.actual.toFixed(2)} > reach ${r.limit.toFixed(1)}`,
+    speed: `Speed violation: transition too fast (${r.actual.toFixed(2)} > ${r.limit.toFixed(1)})`,
+    zone: `Zone violation: hand in wrong zone`,
+  };
+
+  return {
+    constraintId: r.rule,
+    severity: 'hard',
+    message: ruleMessages[r.rule] ?? `${r.rule}: ${r.fingerA}-${r.fingerB}`,
+    fingers: [r.fingerA, r.fingerB],
+    measuredValue: r.actual,
+    threshold: r.limit,
+  };
+}
+
+// ============================================================================
+// Main Validation Entry Point
+// ============================================================================
+
+/**
+ * Run full validation on a layout + assignment + moment.
+ *
+ * 1. Build EvaluationConfig
+ * 2. validateAssignment (consistency checks)
+ * 3. evaluateEvent (cost evaluation)
+ * 4. Extract grip diagnostic evidence
+ * 5. Run direct pairwise constraint checks
+ * 6. Assemble ValidatorResult
+ */
+export function runValidation(
+  layout: Layout,
+  padFingerAssignment: PadFingerAssignment,
+  moment: PerformanceMoment,
+): ValidatorResult {
+  const config = buildEvaluationConfig(layout);
+
+  // 1. Validate assignment consistency
+  const assignmentValidation = validateAssignment({
+    layout,
+    padFingerAssignment,
+    moments: [moment],
+    config,
+  });
+
+  // 2. Evaluate event cost (may fail gracefully if assignment is invalid)
+  let eventBreakdown;
+  try {
+    eventBreakdown = evaluateEvent({
+      moment,
+      layout,
+      padFingerAssignment,
+      config,
+      includeDebug: true,
+    });
+  } catch {
+    eventBreakdown = null;
+  }
+
+  // 3. Get active pad keys from moment
+  const activePadKeys: string[] = [];
+  for (const note of moment.notes) {
+    if (note.padId) {
+      activePadKeys.push(note.padId);
+    } else {
+      // Try to find pad from layout by voiceId/soundId
+      const found = findPadForSound(note.soundId, layout);
+      if (found) activePadKeys.push(found);
+    }
+  }
+
+  // 4. Extract grip diagnostic evidence
+  const gripRejections = extractGripEvidence(padFingerAssignment, activePadKeys);
+  const gripEvidence = gripRejections.map(gripRejectionToEvidence);
+
+  // 5. Direct pairwise constraint checks
+  const directEvidence = runDirectConstraintChecks(padFingerAssignment, activePadKeys);
+
+  // 6. Assignment issue evidence
+  const assignmentEvidence: ConstraintViolationEvidence[] = assignmentValidation.issues.map(issue => ({
+    constraintId: issue.type === 'unmapped_note' ? 'unmapped_note' as const
+      : issue.type === 'ownership_conflict' ? 'ownership_conflict' as const
+      : 'missing_assignment' as const,
+    severity: 'hard' as const,
+    message: issue.message,
+    pads: issue.padKey ? [issue.padKey] : undefined,
+  }));
+
+  // 7. Check for pads with no finger assignment
+  const missingAssignmentEvidence: ConstraintViolationEvidence[] = [];
+  for (const pk of activePadKeys) {
+    if (!padFingerAssignment[pk]) {
+      missingAssignmentEvidence.push({
+        constraintId: 'missing_assignment',
+        severity: 'hard',
+        message: `Active pad ${pk} has no finger assignment`,
+        pads: [pk],
+      });
+    }
+  }
+
+  // Deduplicate evidence by constraintId + message
+  const allEvidenceRaw = [...directEvidence, ...gripEvidence, ...assignmentEvidence, ...missingAssignmentEvidence];
+  const seen = new Set<string>();
+  const evidence: ConstraintViolationEvidence[] = [];
+  for (const e of allEvidenceRaw) {
+    const key = `${e.constraintId}:${e.message}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      evidence.push(e);
+    }
+  }
+
+  // Determine overall status
+  const hasViolation = evidence.length > 0 || !assignmentValidation.valid;
+
+  return {
+    status: hasViolation ? 'violation' : 'valid',
+    feasibilityTier: eventBreakdown?.feasibilityTier ?? 'strict',
+    dimensions: eventBreakdown?.dimensions ?? createZeroCostDimensions(),
+    poseDetail: eventBreakdown?.poseDetail ?? { attractor: 0, perFingerHome: 0, fingerDominance: 0 },
+    eventBreakdown: eventBreakdown ?? null,
+    assignmentValidation,
+    evidence,
+    gripRejections,
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Find the pad key for a given soundId/voiceId in the layout.
+ */
+function findPadForSound(soundId: string, layout: Layout): string | null {
+  for (const [pk, voice] of Object.entries(layout.padToVoice)) {
+    if (voice.id === soundId) return pk;
+  }
+  return null;
+}
+
+/**
+ * Update moment's NoteInstance padIds to match the current layout.
+ * Called after pad moves to keep the moment consistent.
+ */
+export function updateMomentPadIds(
+  moment: PerformanceMoment,
+  layout: Layout,
+): PerformanceMoment {
+  return {
+    ...moment,
+    notes: moment.notes.map(note => {
+      const newPadKey = findPadForSound(note.soundId, layout);
+      return { ...note, padId: newPadKey ?? note.padId };
+    }),
+  };
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/validator/validatorScenarios.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/validator/validatorScenarios.ts
@@ -1,0 +1,369 @@
+/**
+ * Validator Scenarios.
+ *
+ * Curated set of atomic constraint test cases for the Constraint Validator.
+ * Each scenario provides a pre-built layout, finger assignment, and moment
+ * that demonstrates a specific constraint violation (or valid state).
+ *
+ * These are NOT solver-generated — each scenario manually specifies which
+ * finger owns which pad, and the validator checks feasibility directly.
+ */
+
+import { type ValidatorScenario } from './types';
+import { type Layout } from '../../types/layout';
+import { type PadFingerAssignment } from '../../types/executionPlan';
+import { type PerformanceMoment, type NoteInstance } from '../../types/performanceEvent';
+import { type Voice } from '../../types/voice';
+import { padKey } from '../../types/padGrid';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeVoice(id: string, name: string, noteNumber: number, color: string): Voice {
+  return { id, name, sourceType: 'midi_track', sourceFile: '', originalMidiNote: noteNumber, color };
+}
+
+function makeNote(soundId: string, padId: string, noteNumber: number): NoteInstance {
+  return { soundId, padId, noteNumber, velocity: 100 };
+}
+
+function makeMoment(notes: NoteInstance[]): PerformanceMoment {
+  return { momentIndex: 0, startTime: 0, notes };
+}
+
+function makeLayout(
+  id: string,
+  name: string,
+  entries: Array<{ row: number; col: number; voice: Voice }>,
+): Layout {
+  const padToVoice: Record<string, Voice> = {};
+  for (const e of entries) {
+    padToVoice[padKey(e.row, e.col)] = e.voice;
+  }
+  return {
+    id,
+    name,
+    padToVoice,
+    fingerConstraints: {},
+    placementLocks: {},
+    scoreCache: null,
+    layoutMode: 'manual',
+    role: 'active',
+  };
+}
+
+// ============================================================================
+// Scenario Definitions
+// ============================================================================
+
+const SCENARIOS: ValidatorScenario[] = [
+  // --------------------------------------------------------------------------
+  // V1: Same Finger Owns Two Active Pads (Collision)
+  // --------------------------------------------------------------------------
+  (() => {
+    const vKick = makeVoice('v1-kick', 'Kick', 64, '#ef4444');
+    const vSnare = makeVoice('v1-snare', 'Snare', 65, '#3b82f6');
+    const layout = makeLayout('v1-layout', 'Collision Test', [
+      { row: 3, col: 4, voice: vKick },
+      { row: 3, col: 5, voice: vSnare },
+    ]);
+    return {
+      id: 'V1',
+      title: 'Collision: Same Finger on Two Active Pads',
+      description: 'Right index is assigned to both pads (3,4) and (3,5). Both notes are active simultaneously, so the same finger must be in two places at once.',
+      constraintIds: ['collision'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'index' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vKick.id, padKey(3, 4), 64),
+        makeNote(vSnare.id, padKey(3, 5), 65),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V2: Span Violation — Index-Middle Exceed 2.0
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v2-a', 'Sound A', 62, '#ef4444');
+    const vB = makeVoice('v2-b', 'Sound B', 65, '#3b82f6');
+    const layout = makeLayout('v2-layout', 'Span Violation Test', [
+      { row: 3, col: 2, voice: vA },
+      { row: 3, col: 5, voice: vB },
+    ]);
+    return {
+      id: 'V2',
+      title: 'Span: Index-Middle Exceed 2.0',
+      description: 'Right index at (3,2) and right middle at (3,5). Distance = 3.0, but index-middle max span = 2.0.',
+      constraintIds: ['span'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 2)]: { hand: 'right', finger: 'index' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'middle' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(3, 2), 62),
+        makeNote(vB.id, padKey(3, 5), 65),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V3: Span Start Valid, Drag to Break
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v3-a', 'Sound A', 64, '#ef4444');
+    const vB = makeVoice('v3-b', 'Sound B', 65, '#3b82f6');
+    const layout = makeLayout('v3-layout', 'Span Valid Start', [
+      { row: 3, col: 4, voice: vA },
+      { row: 3, col: 5, voice: vB },
+    ]);
+    return {
+      id: 'V3',
+      title: 'Span: Start Valid, Drag to Break',
+      description: 'Right index at (3,4) and right middle at (3,5). Distance = 1.0 ≤ 2.0 max. Drag Sound B to col 7 to create a span violation.',
+      constraintIds: ['span'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'middle' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(3, 4), 64),
+        makeNote(vB.id, padKey(3, 5), 65),
+      ]),
+      expectedInitialStatus: 'valid',
+      fixHint: 'Drag Sound B from (3,5) to (3,7) to see a span violation appear.',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V4: Ordering Violation — Index Right of Middle (Right Hand)
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v4-a', 'Sound A', 66, '#ef4444');
+    const vB = makeVoice('v4-b', 'Sound B', 64, '#3b82f6');
+    const layout = makeLayout('v4-layout', 'Ordering Violation Test', [
+      { row: 3, col: 6, voice: vA },
+      { row: 3, col: 4, voice: vB },
+    ]);
+    return {
+      id: 'V4',
+      title: 'Ordering: Index Right of Middle (Crossover)',
+      description: 'Right index at col 6, right middle at col 4. Right hand requires index left of middle, so this is a crossover violation.',
+      constraintIds: ['ordering'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 6)]: { hand: 'right', finger: 'index' },
+        [padKey(3, 4)]: { hand: 'right', finger: 'middle' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(3, 6), 66),
+        makeNote(vB.id, padKey(3, 4), 64),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V5: Thumb Delta — Thumb 2 Rows Above Index
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v5-a', 'Sound A', 75, '#ef4444');
+    const vB = makeVoice('v5-b', 'Sound B', 64, '#3b82f6');
+    const layout = makeLayout('v5-layout', 'Thumb Delta Test', [
+      { row: 5, col: 4, voice: vA },
+      { row: 3, col: 5, voice: vB },
+    ]);
+    return {
+      id: 'V5',
+      title: 'Thumb Delta: Thumb 2 Rows Above Index',
+      description: 'Right thumb at row 5, right index at row 3. Thumb row offset = 2.0, but THUMB_DELTA max = 1.0.',
+      constraintIds: ['thumbDelta'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(5, 4)]: { hand: 'right', finger: 'thumb' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'index' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(5, 4), 75),
+        makeNote(vB.id, padKey(3, 5), 64),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V6: Reachability — Maximum Grid Distance
+  // --------------------------------------------------------------------------
+  (() => {
+    const vLow = makeVoice('v6-low', 'Low', 36, '#ef4444');
+    const vHigh = makeVoice('v6-high', 'High', 99, '#3b82f6');
+    const layout = makeLayout('v6-layout', 'Reachability Test', [
+      { row: 0, col: 0, voice: vLow },
+      { row: 7, col: 7, voice: vHigh },
+    ]);
+    return {
+      id: 'V6',
+      title: 'Reachability: Max Grid Distance',
+      description: 'Right thumb at (0,0) and right pinky at (7,7). Distance = 9.9, far beyond thumb-pinky max span of 5.5.',
+      constraintIds: ['span'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(0, 0)]: { hand: 'right', finger: 'thumb' },
+        [padKey(7, 7)]: { hand: 'right', finger: 'pinky' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vLow.id, padKey(0, 0), 36),
+        makeNote(vHigh.id, padKey(7, 7), 99),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V7: Unmapped Note — Sound Not in Layout
+  // --------------------------------------------------------------------------
+  (() => {
+    const vKick = makeVoice('v7-kick', 'Kick', 64, '#ef4444');
+    const vSnare = makeVoice('v7-snare', 'Snare', 65, '#3b82f6');
+    // Only Kick is in the layout — Snare is unmapped
+    const layout = makeLayout('v7-layout', 'Unmapped Note Test', [
+      { row: 3, col: 4, voice: vKick },
+    ]);
+    return {
+      id: 'V7',
+      title: 'Unmapped Note: Sound Not in Layout',
+      description: 'The moment requires both Kick and Snare, but only Kick has a pad in the layout. Snare has no mapped pad.',
+      constraintIds: ['reachability'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vKick.id, padKey(3, 4), 64),
+        makeNote(vSnare.id, '', 65), // empty padId — unmapped
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V8: Missing Finger Assignment
+  // --------------------------------------------------------------------------
+  (() => {
+    const vKick = makeVoice('v8-kick', 'Kick', 64, '#ef4444');
+    const vSnare = makeVoice('v8-snare', 'Snare', 65, '#3b82f6');
+    const layout = makeLayout('v8-layout', 'Missing Assignment Test', [
+      { row: 3, col: 4, voice: vKick },
+      { row: 3, col: 5, voice: vSnare },
+    ]);
+    return {
+      id: 'V8',
+      title: 'Missing Finger Assignment',
+      description: 'Both Kick and Snare have pads, but only Kick has a finger assignment. Snare at (3,5) has no finger owner.',
+      constraintIds: ['zone'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+        // (3,5) intentionally missing
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vKick.id, padKey(3, 4), 64),
+        makeNote(vSnare.id, padKey(3, 5), 65),
+      ]),
+      expectedInitialStatus: 'violation',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V9: Valid But Degraded — High Cost, Still Feasible
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v9-a', 'Sound A', 62, '#ef4444');
+    const vB = makeVoice('v9-b', 'Sound B', 65, '#3b82f6');
+    const vC = makeVoice('v9-c', 'Sound C', 71, '#22c55e');
+    const layout = makeLayout('v9-layout', 'Valid But Degraded', [
+      { row: 3, col: 2, voice: vA },
+      { row: 3, col: 5, voice: vB },
+      { row: 4, col: 3, voice: vC },
+    ]);
+    // thumb(2) < middle(3) < pinky(5) for right hand — valid ordering
+    // thumb-pinky = sqrt((5-2)^2) = 3.0 ≤ 5.5 OK
+    // thumb-middle = sqrt((3-2)^2 + (4-3)^2) = sqrt(2) ≈ 1.41 ≤ 4.5 OK
+    // middle-pinky = sqrt((5-3)^2 + (3-4)^2) = sqrt(5) ≈ 2.24 ≤ 2.5 OK
+    return {
+      id: 'V9',
+      title: 'Valid But Degraded: High Cost, Feasible',
+      description: 'Three pads using thumb, middle, and pinky — weak finger choices with moderate spread. Feasible but high cost.',
+      constraintIds: ['span'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 2)]: { hand: 'right', finger: 'thumb' },
+        [padKey(4, 3)]: { hand: 'right', finger: 'middle' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'pinky' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(3, 2), 62),
+        makeNote(vB.id, padKey(3, 5), 65),
+        makeNote(vC.id, padKey(4, 3), 71),
+      ]),
+      expectedInitialStatus: 'valid',
+    } satisfies ValidatorScenario;
+  })(),
+
+  // --------------------------------------------------------------------------
+  // V10: Dense Valid Cluster — Compact Right Hand
+  // --------------------------------------------------------------------------
+  (() => {
+    const vA = makeVoice('v10-a', 'Sound A', 64, '#ef4444');
+    const vB = makeVoice('v10-b', 'Sound B', 65, '#3b82f6');
+    const vC = makeVoice('v10-c', 'Sound C', 66, '#22c55e');
+    const layout = makeLayout('v10-layout', 'Dense Valid Cluster', [
+      { row: 3, col: 4, voice: vA },
+      { row: 3, col: 5, voice: vB },
+      { row: 3, col: 6, voice: vC },
+    ]);
+    // index(4) < middle(5) < ring(6) — valid right hand ordering
+    // index-middle = 1.0 ≤ 2.0, middle-ring = 1.0 ≤ 2.0, index-ring = 2.0 ≤ 2.0 — OK
+    return {
+      id: 'V10',
+      title: 'Dense Valid Cluster: Compact Right Hand',
+      description: 'Three adjacent pads with index, middle, ring. All spans within limits. Drag Sound C far left to create crossover + span violations.',
+      constraintIds: ['span', 'ordering'] as const,
+      layout,
+      padFingerAssignment: {
+        [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+        [padKey(3, 5)]: { hand: 'right', finger: 'middle' },
+        [padKey(3, 6)]: { hand: 'right', finger: 'ring' },
+      } satisfies PadFingerAssignment,
+      moment: makeMoment([
+        makeNote(vA.id, padKey(3, 4), 64),
+        makeNote(vB.id, padKey(3, 5), 65),
+        makeNote(vC.id, padKey(3, 6), 66),
+      ]),
+      expectedInitialStatus: 'valid',
+      fixHint: 'Drag Sound C from (3,6) to (3,0) to create ordering and span violations.',
+    } satisfies ValidatorScenario;
+  })(),
+];
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/** Get all validator scenarios. */
+export function getValidatorScenarios(): ValidatorScenario[] {
+  return SCENARIOS;
+}
+
+/** Get a specific scenario by ID. */
+export function getValidatorScenario(id: string): ValidatorScenario | undefined {
+  return SCENARIOS.find(s => s.id === id);
+}

--- a/product-reconciliation/v2/v2 repo/test/validator/validatorEngine.test.ts
+++ b/product-reconciliation/v2/v2 repo/test/validator/validatorEngine.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Validator Engine Tests.
+ *
+ * Proves the evaluation bridge works independently of the beam solver.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runValidation, buildEvaluationConfig } from '../../src/ui/validator/validatorEngine';
+import { getValidatorScenario } from '../../src/ui/validator/validatorScenarios';
+import { padKey } from '../../src/types/padGrid';
+import { type Layout } from '../../src/types/layout';
+import { type Voice } from '../../src/types/voice';
+
+function makeVoice(id: string, noteNumber: number): Voice {
+  return { id, name: `Sound ${noteNumber}`, sourceType: 'midi_track', sourceFile: '', originalMidiNote: noteNumber, color: '#fff' };
+}
+
+describe('buildEvaluationConfig', () => {
+  it('should produce a valid EvaluationConfig', () => {
+    const layout: Layout = {
+      id: 'test', name: 'Test', padToVoice: {
+        [padKey(3, 4)]: makeVoice('v1', 64),
+      },
+      fingerConstraints: {}, placementLocks: {}, scoreCache: null, role: 'active',
+    };
+    const config = buildEvaluationConfig(layout);
+    expect(config.restingPose).toBeDefined();
+    expect(config.stiffness).toBe(0.3);
+    expect(config.instrumentConfig.rows).toBe(8);
+    expect(config.instrumentConfig.cols).toBe(8);
+    expect(config.neutralHandCenters).toBeDefined();
+  });
+});
+
+describe('runValidation', () => {
+  it('should detect span violation (V2)', () => {
+    const scenario = getValidatorScenario('V2')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'span')).toBe(true);
+    const spanEvidence = result.evidence.find(e => e.constraintId === 'span');
+    expect(spanEvidence?.fingers).toContain('index');
+    expect(spanEvidence?.fingers).toContain('middle');
+    expect(spanEvidence?.measuredValue).toBeGreaterThan(2.0);
+  });
+
+  it('should detect ordering violation (V4)', () => {
+    const scenario = getValidatorScenario('V4')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'ordering')).toBe(true);
+  });
+
+  it('should detect thumb delta violation (V5)', () => {
+    const scenario = getValidatorScenario('V5')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'thumbDelta')).toBe(true);
+    const thumbEvidence = result.evidence.find(e => e.constraintId === 'thumbDelta');
+    expect(thumbEvidence?.measuredValue).toBeGreaterThan(1.0);
+  });
+
+  it('should detect collision / same-finger conflict (V1)', () => {
+    const scenario = getValidatorScenario('V1')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'collision')).toBe(true);
+  });
+
+  it('should detect span reachability violation (V6)', () => {
+    const scenario = getValidatorScenario('V6')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'span')).toBe(true);
+  });
+
+  it('should detect unmapped note (V7)', () => {
+    const scenario = getValidatorScenario('V7')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+  });
+
+  it('should detect missing assignment (V8)', () => {
+    const scenario = getValidatorScenario('V8')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('violation');
+    expect(result.evidence.some(e => e.constraintId === 'missing_assignment')).toBe(true);
+  });
+
+  it('should mark valid scenario as valid (V3)', () => {
+    const scenario = getValidatorScenario('V3')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('valid');
+    expect(result.evidence).toHaveLength(0);
+    expect(result.dimensions.total).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should mark valid-but-degraded as valid (V9)', () => {
+    const scenario = getValidatorScenario('V9')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('valid');
+    expect(result.dimensions.poseNaturalness).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should mark dense valid cluster as valid (V10)', () => {
+    const scenario = getValidatorScenario('V10')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.status).toBe('valid');
+    expect(result.evidence).toHaveLength(0);
+  });
+
+  it('should include CostDimensions in result', () => {
+    const scenario = getValidatorScenario('V10')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.dimensions).toBeDefined();
+    expect(typeof result.dimensions.poseNaturalness).toBe('number');
+    expect(typeof result.dimensions.transitionCost).toBe('number');
+    expect(typeof result.dimensions.constraintPenalty).toBe('number');
+    expect(typeof result.dimensions.alternation).toBe('number');
+    expect(typeof result.dimensions.handBalance).toBe('number');
+    expect(typeof result.dimensions.total).toBe('number');
+  });
+
+  it('should include poseDetail in result', () => {
+    const scenario = getValidatorScenario('V10')!;
+    const result = runValidation(scenario.layout, scenario.padFingerAssignment, scenario.moment);
+    expect(result.poseDetail).toBeDefined();
+    expect(typeof result.poseDetail.attractor).toBe('number');
+    expect(typeof result.poseDetail.perFingerHome).toBe('number');
+    expect(typeof result.poseDetail.fingerDominance).toBe('number');
+  });
+});

--- a/product-reconciliation/v2/v2 repo/test/validator/validatorScenarios.test.ts
+++ b/product-reconciliation/v2/v2 repo/test/validator/validatorScenarios.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Validator Scenario Integrity Tests.
+ *
+ * Verifies that every curated scenario:
+ * 1. Has valid structure (layout, assignment, moment)
+ * 2. Produces the expected initial status (violation or valid)
+ * 3. Contains the expected constraint violation types
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getValidatorScenarios, getValidatorScenario } from '../../src/ui/validator/validatorScenarios';
+import { runValidation } from '../../src/ui/validator/validatorEngine';
+
+describe('validatorScenarios integrity', () => {
+  const scenarios = getValidatorScenarios();
+
+  it('should have at least 10 scenarios', () => {
+    expect(scenarios.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('should have unique IDs', () => {
+    const ids = scenarios.map(s => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('should find scenarios by ID', () => {
+    for (const s of scenarios) {
+      expect(getValidatorScenario(s.id)).toBeDefined();
+      expect(getValidatorScenario(s.id)!.id).toBe(s.id);
+    }
+  });
+
+  it('should return undefined for unknown ID', () => {
+    expect(getValidatorScenario('NONEXISTENT')).toBeUndefined();
+  });
+
+  for (const scenario of scenarios) {
+    describe(`scenario ${scenario.id}: ${scenario.title}`, () => {
+      it('should have valid structure', () => {
+        expect(scenario.layout).toBeDefined();
+        expect(scenario.layout.padToVoice).toBeDefined();
+        expect(Object.keys(scenario.layout.padToVoice).length).toBeGreaterThan(0);
+        expect(scenario.padFingerAssignment).toBeDefined();
+        expect(scenario.moment).toBeDefined();
+        expect(scenario.moment.notes.length).toBeGreaterThan(0);
+        expect(scenario.constraintIds.length).toBeGreaterThan(0);
+      });
+
+      it(`should produce expectedInitialStatus = '${scenario.expectedInitialStatus}'`, () => {
+        const result = runValidation(
+          scenario.layout,
+          scenario.padFingerAssignment,
+          scenario.moment,
+        );
+        expect(result.status).toBe(scenario.expectedInitialStatus);
+      });
+
+      if (scenario.expectedInitialStatus === 'violation') {
+        it('should produce at least one evidence item', () => {
+          const result = runValidation(
+            scenario.layout,
+            scenario.padFingerAssignment,
+            scenario.moment,
+          );
+          expect(result.evidence.length).toBeGreaterThan(0);
+        });
+      }
+
+      if (scenario.expectedInitialStatus === 'valid') {
+        it('should produce zero evidence items', () => {
+          const result = runValidation(
+            scenario.layout,
+            scenario.padFingerAssignment,
+            scenario.moment,
+          );
+          expect(result.evidence).toHaveLength(0);
+        });
+
+        it('should have non-negative total cost', () => {
+          const result = runValidation(
+            scenario.layout,
+            scenario.padFingerAssignment,
+            scenario.moment,
+          );
+          expect(result.dimensions.total).toBeGreaterThanOrEqual(0);
+        });
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds a dedicated `/validator` route with a purpose-built constraint validator page that demonstrates hard-rule detection on single-moment examples without the solver
- 10 curated scenarios (V1-V10) covering collision, span, ordering, thumbDelta, reachability, unmapped notes, missing assignments, and valid configurations
- Three-panel UI: scenario selection, interactive 8x8 grid (drag pads, reassign fingers), and results panel with cost dimensions and violation evidence
- Replaces A1-A8 demo group on home page; removes unused Import Project JSON button
- 50 new tests (526 total), clean build

## Test plan
- [x] `npm run test:run` — 526/526 pass (50 new + 476 existing)
- [x] `npm run build` — clean, no type errors
- [x] Verified home page shows Constraint Validator button, no A1-A8 group
- [x] Verified /validator renders violation scenarios with evidence cards
- [x] Verified /validator renders valid scenarios with cost dimensions
- [x] Verified scenario switching, pad drag, and finger reassignment trigger re-evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)