### PR TITLE
Add Events tab to workspace left panel, remove Workspace Flow card

### DIFF
--- a/product-reconciliation/v2/v2 repo/src/ui/components/EventsPanel.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/EventsPanel.tsx
@@ -1,0 +1,283 @@
+/**
+ * EventsPanel.
+ *
+ * Temporal event navigator for the workspace. Derives PerformanceMoments
+ * (polyphonic groups of simultaneous notes) from active SoundStreams and
+ * renders them as a scrollable, selectable list.
+ *
+ * Selecting a moment:
+ * - dispatches SELECT_EVENT for the first matching FingerAssignment
+ * - scrolls the timeline to the event's time position
+ * - exposes selection state for downstream grid/onion-view consumers
+ *
+ * Reuses V1 event-analysis patterns: epsilon-based temporal grouping,
+ * keyboard navigation (ArrowUp/Down, j/k), auto-scroll selected row.
+ */
+
+import { useMemo, useCallback, useEffect, useRef } from 'react';
+import { useProject } from '../state/ProjectContext';
+import { getActiveStreams, type SoundStream } from '../state/projectState';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+/** Maximum time gap (seconds) to consider events simultaneous. */
+const MOMENT_EPSILON = 0.001;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A grouped moment in the performance timeline (polyphonic event). */
+export interface PerformanceMomentSummary {
+  momentIndex: number;
+  startTime: number;
+  beatPosition: string;
+  sounds: Array<{ name: string; color: string; streamId: string }>;
+  noteCount: number;
+}
+
+// ─── Moment Derivation ──────────────────────────────────────────────────────
+
+function formatBeatPosition(time: number, tempo: number): string {
+  const beatDuration = 60 / (tempo || 120);
+  const totalBeats = time / beatDuration;
+  const bar = Math.floor(totalBeats / 4) + 1;
+  const beat = Math.floor(totalBeats % 4) + 1;
+  const subBeat = totalBeats % 1;
+  if (subBeat < 0.01) return `${bar}.${beat}`;
+  return `${bar}.${beat}`;
+}
+
+function groupCurrentMoment(
+  group: Array<{ startTime: number; streamId: string; name: string; color: string }>,
+  momentIndex: number,
+  tempo: number,
+): PerformanceMomentSummary {
+  const time = group[0].startTime;
+  const soundMap = new Map<string, { name: string; color: string; streamId: string }>();
+  for (const e of group) {
+    if (!soundMap.has(e.streamId)) {
+      soundMap.set(e.streamId, { name: e.name, color: e.color, streamId: e.streamId });
+    }
+  }
+  return {
+    momentIndex,
+    startTime: time,
+    beatPosition: formatBeatPosition(time, tempo),
+    sounds: Array.from(soundMap.values()),
+    noteCount: group.length,
+  };
+}
+
+/**
+ * Derive PerformanceMoments from active SoundStreams.
+ * Groups events across all streams by startTime within MOMENT_EPSILON.
+ * Adapted from V1 groupDebugEventsIntoMoments pattern.
+ */
+export function derivePerformanceMoments(
+  streams: SoundStream[],
+  tempo: number,
+): PerformanceMomentSummary[] {
+  const allEvents: Array<{ startTime: number; streamId: string; name: string; color: string }> = [];
+  for (const stream of streams) {
+    for (const event of stream.events) {
+      allEvents.push({
+        startTime: event.startTime,
+        streamId: stream.id,
+        name: stream.name,
+        color: stream.color,
+      });
+    }
+  }
+
+  allEvents.sort((a, b) => a.startTime - b.startTime);
+
+  const moments: PerformanceMomentSummary[] = [];
+  let currentGroup: typeof allEvents = [];
+  let currentTime = -Infinity;
+
+  for (const event of allEvents) {
+    if (event.startTime - currentTime > MOMENT_EPSILON) {
+      if (currentGroup.length > 0) {
+        moments.push(groupCurrentMoment(currentGroup, moments.length, tempo));
+      }
+      currentGroup = [event];
+      currentTime = event.startTime;
+    } else {
+      currentGroup.push(event);
+    }
+  }
+
+  if (currentGroup.length > 0) {
+    moments.push(groupCurrentMoment(currentGroup, moments.length, tempo));
+  }
+
+  return moments;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function EventsPanel() {
+  const { state, dispatch } = useProject();
+  const activeStreams = getActiveStreams(state);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const moments = useMemo(
+    () => derivePerformanceMoments(activeStreams, state.tempo),
+    [activeStreams, state.tempo],
+  );
+
+  // Determine which moment is currently selected based on selectedEventIndex
+  const selectedMomentIdx = useMemo(() => {
+    if (state.selectedEventIndex === null) return null;
+    const assignments = state.analysisResult?.executionPlan.fingerAssignments;
+    if (!assignments) return null;
+    const selected = assignments.find(a => a.eventIndex === state.selectedEventIndex);
+    if (!selected) return null;
+    const idx = moments.findIndex(m => Math.abs(m.startTime - selected.startTime) < MOMENT_EPSILON);
+    return idx >= 0 ? idx : null;
+  }, [state.selectedEventIndex, state.analysisResult, moments]);
+
+  const handleMomentClick = useCallback((moment: PerformanceMomentSummary) => {
+    const assignments = state.analysisResult?.executionPlan.fingerAssignments;
+    if (assignments) {
+      const match = assignments.find(
+        a => Math.abs(a.startTime - moment.startTime) < MOMENT_EPSILON
+      );
+      if (match?.eventIndex !== undefined) {
+        dispatch({ type: 'SELECT_EVENT', payload: match.eventIndex });
+        return;
+      }
+    }
+    // Fallback: move playhead to the moment's time for timeline scrolling
+    dispatch({ type: 'SET_CURRENT_TIME', payload: moment.startTime });
+  }, [state.analysisResult, dispatch]);
+
+  // Keyboard navigation (V1 pattern: ArrowUp/Down, j/k)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      if (moments.length === 0) return;
+
+      const currentIdx = selectedMomentIdx ?? -1;
+
+      if (e.key === 'ArrowDown' || e.key === 'j') {
+        e.preventDefault();
+        const nextIdx = Math.min(currentIdx + 1, moments.length - 1);
+        handleMomentClick(moments[nextIdx]);
+      } else if (e.key === 'ArrowUp' || e.key === 'k') {
+        e.preventDefault();
+        const prevIdx = Math.max(currentIdx - 1, 0);
+        handleMomentClick(moments[prevIdx]);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [moments, selectedMomentIdx, handleMomentClick]);
+
+  // Auto-scroll selected moment row into view (V1 pattern)
+  useEffect(() => {
+    if (selectedMomentIdx === null || !listRef.current) return;
+    const row = listRef.current.querySelector(`[data-moment-index="${selectedMomentIdx}"]`);
+    row?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }, [selectedMomentIdx]);
+
+  if (moments.length === 0) {
+    return (
+      <div className="py-6 text-center text-xs text-gray-500">
+        No events. Import MIDI or compose a pattern.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between px-1">
+        <span className="text-[10px] text-gray-500">
+          {moments.length} events
+        </span>
+        {selectedMomentIdx !== null && (
+          <button
+            className="text-[10px] text-gray-500 hover:text-gray-300"
+            onClick={() => dispatch({ type: 'SELECT_EVENT', payload: null })}
+          >
+            Deselect
+          </button>
+        )}
+      </div>
+
+      <div ref={listRef} className="overflow-y-auto space-y-0.5" style={{ maxHeight: 'calc(100vh - 280px)' }}>
+        {moments.map((moment) => (
+          <MomentRow
+            key={moment.momentIndex}
+            moment={moment}
+            isSelected={selectedMomentIdx === moment.momentIndex}
+            onClick={() => handleMomentClick(moment)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────────────
+
+function MomentRow({
+  moment,
+  isSelected,
+  onClick,
+}: {
+  moment: PerformanceMomentSummary;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      data-moment-index={moment.momentIndex}
+      className={`
+        w-full text-left px-2 py-1.5 rounded-md text-xs transition-colors
+        ${isSelected
+          ? 'bg-blue-600/20 border border-blue-500/40 text-gray-100'
+          : 'hover:bg-gray-800/50 border border-transparent text-gray-300'
+        }
+      `}
+      onClick={onClick}
+    >
+      <div className="flex items-center gap-2">
+        {/* Event label */}
+        <span className={`text-[10px] font-mono w-14 flex-shrink-0 ${isSelected ? 'text-blue-300' : 'text-gray-500'}`}>
+          Event {String(moment.momentIndex + 1).padStart(2, '0')}
+        </span>
+
+        {/* Beat position */}
+        <span className="text-[10px] font-mono w-6 flex-shrink-0 text-gray-400">
+          {moment.beatPosition}
+        </span>
+
+        {/* Sound badges */}
+        <div className="flex-1 flex flex-wrap gap-0.5 min-w-0">
+          {moment.sounds.map((sound) => (
+            <span
+              key={sound.streamId}
+              className="px-1 py-0 rounded text-[9px] font-medium truncate max-w-[60px]"
+              style={{
+                backgroundColor: sound.color + '30',
+                color: sound.color,
+                border: `1px solid ${sound.color}50`,
+              }}
+              title={sound.name}
+            >
+              {sound.name}
+            </span>
+          ))}
+        </div>
+
+        {/* Note count badge */}
+        <span className={`text-[10px] flex-shrink-0 ${
+          moment.noteCount > 3 ? 'text-amber-400' : 'text-gray-500'
+        }`}>
+          {moment.noteCount}n
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/components/UnifiedTimeline.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/UnifiedTimeline.tsx
@@ -223,6 +223,35 @@ export function UnifiedTimeline() {
   const timelineWidth = totalDuration * zoom + 100;
   const totalHeight = visibleStreams.length * TRACK_HEIGHT;
 
+  // ─── Auto-scroll to selected event ────────────────────────────────────
+  const prevSelectedRef = useRef(state.selectedEventIndex);
+  useEffect(() => {
+    if (
+      state.selectedEventIndex === null ||
+      state.selectedEventIndex === prevSelectedRef.current ||
+      !scrollContainerRef.current
+    ) {
+      prevSelectedRef.current = state.selectedEventIndex;
+      return;
+    }
+    prevSelectedRef.current = state.selectedEventIndex;
+
+    // Find the startTime of the selected event from assignments
+    const allAssignments = Array.from(streamAssignments.values()).flat();
+    const selected = allAssignments.find(a => a.eventIndex === state.selectedEventIndex);
+    if (!selected) return;
+
+    const x = (selected.startTime - minTime) * zoom;
+    const container = scrollContainerRef.current;
+    const viewWidth = container.clientWidth;
+
+    // Only scroll if the event is outside the visible area
+    const scrollLeft = container.scrollLeft;
+    if (x < scrollLeft || x > scrollLeft + viewWidth - 40) {
+      container.scrollTo({ left: Math.max(0, x - viewWidth / 3), behavior: 'smooth' });
+    }
+  }, [state.selectedEventIndex, streamAssignments, minTime, zoom]);
+
   // ─── Handlers ────────────────────────────────────────────────────────────
 
   const handleImportClick = useCallback(() => {

--- a/product-reconciliation/v2/v2 repo/src/ui/components/workspace/PerformanceWorkspace.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/workspace/PerformanceWorkspace.tsx
@@ -4,6 +4,7 @@ import { useProject } from '../../state/ProjectContext';
 import { saveProject } from '../../persistence/projectStorage';
 import { EditorToolbar } from '../EditorToolbar';
 import { VoicePalette } from '../VoicePalette';
+import { EventsPanel } from '../EventsPanel';
 import { InteractiveGrid } from '../InteractiveGrid';
 import { CompareGridView } from '../CompareGridView';
 import { AnalysisSidePanel } from '../AnalysisSidePanel';
@@ -13,6 +14,8 @@ import { TransitionDetailPanel } from './TransitionDetailPanel';
 import { UnifiedTimeline } from '../UnifiedTimeline';
 import { useAutoAnalysis } from '../../hooks/useAutoAnalysis';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+
+type LeftPanelTab = 'sounds' | 'events';
 
 export function PerformanceWorkspace() {
   const { state, dispatch } = useProject();
@@ -25,6 +28,7 @@ export function PerformanceWorkspace() {
   const [showDiagnostics, setShowDiagnostics] = useState(false);
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [onionSkin, setOnionSkin] = useState(false);
+  const [leftTab, setLeftTab] = useState<LeftPanelTab>('sounds');
 
   const assignments = state.analysisResult?.executionPlan.fingerAssignments;
   const selectedCandidate = state.candidates.find(candidate => candidate.id === state.selectedCandidateId) ?? null;
@@ -88,38 +92,62 @@ export function PerformanceWorkspace() {
         className="grid gap-4 items-start"
         style={{ gridTemplateColumns: gridExpanded ? '1fr' : `${leftCollapsed ? '48px' : '260px'} minmax(0, 1fr)` }}
       >
-        {/* Left Column: Collapsible Sidebar */}
+        {/* Left Column: Collapsible Sidebar with Sounds/Events tabs */}
         {!gridExpanded && (
-        <div className="space-y-3 min-w-0">
+        <div className="min-w-0">
           {leftCollapsed ? (
             <button
               className="flex flex-col items-center gap-3 py-3 w-full cursor-pointer hover:bg-gray-800/30 rounded transition-colors"
               onClick={() => setLeftCollapsed(false)}
               title="Expand sidebar"
             >
-              <span className="text-[10px] text-gray-500" style={{ writingMode: 'vertical-lr' }}>Sounds</span>
+              <span className="text-[10px] text-gray-500" style={{ writingMode: 'vertical-lr' }}>
+                {leftTab === 'sounds' ? 'Sounds' : 'Events'}
+              </span>
               <span className="text-[10px] text-gray-600">▸</span>
             </button>
           ) : (
-            <>
-              <div className="p-3 rounded-lg glass-panel space-y-2">
-                <div className="flex items-center justify-between">
-                  <div className="text-xs font-medium text-gray-400 uppercase tracking-wide">Workspace Flow</div>
-                  <button
-                    className="w-5 h-5 flex items-center justify-center rounded text-gray-600 hover:text-gray-300 hover:bg-gray-700/50 transition-colors text-[10px]"
-                    onClick={() => setLeftCollapsed(true)}
-                    title="Collapse sidebar"
-                  >
-                    ◂
-                  </button>
-                </div>
-                <div className="text-sm text-gray-200">Edit the performance timeline below and watch the Push grid update on the right.</div>
+            <div className="rounded-lg glass-panel overflow-hidden">
+              {/* Tab header */}
+              <div className="flex items-center border-b border-gray-800">
+                <button
+                  className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+                    leftTab === 'sounds'
+                      ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
+                      : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+                  }`}
+                  onClick={() => setLeftTab('sounds')}
+                >
+                  Sounds
+                </button>
+                <button
+                  className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+                    leftTab === 'events'
+                      ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
+                      : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+                  }`}
+                  onClick={() => setLeftTab('events')}
+                >
+                  Events
+                </button>
+                <button
+                  className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-gray-300 hover:bg-gray-700/50 transition-colors text-[10px] flex-shrink-0"
+                  onClick={() => setLeftCollapsed(true)}
+                  title="Collapse sidebar"
+                >
+                  ◂
+                </button>
               </div>
 
-              <div className="p-3 rounded-lg glass-panel">
-                <VoicePalette />
+              {/* Tab content */}
+              <div className="p-3">
+                {leftTab === 'sounds' ? (
+                  <VoicePalette />
+                ) : (
+                  <EventsPanel />
+                )}
               </div>
-            </>
+            </div>
           )}
         </div>
         )}
@@ -178,11 +206,6 @@ export function PerformanceWorkspace() {
 
       {/* ─── Bottom Drawer: Unified Timeline ─────────────────────────────── */}
       <div className="rounded-lg glass-panel overflow-hidden">
-        <div className="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/40">
-          <span className="px-2 py-1 text-xs rounded bg-gray-700 text-gray-200">Timeline</span>
-          <div className="flex-1" />
-          <span className="text-[10px] text-gray-600">Performance timeline with execution analysis</span>
-        </div>
         <UnifiedTimeline />
       </div>
 


### PR DESCRIPTION
- Remove the tutorial-style Workspace Flow card from PerformanceWorkspace
- Add Sounds/Events tab system to the left panel sidebar
- Create EventsPanel component with temporal moment browsing:
  - Derives PerformanceMoments from active SoundStreams (epsilon-based
    temporal grouping, adapted from V1 event analysis patterns)
  - Scrollable event list showing beat position, active sounds, note count
  - Keyboard navigation (ArrowUp/Down, j/k) with auto-scroll
  - Clicking a moment dispatches SELECT_EVENT for timeline/grid coupling
  - Density badge highlights high-polyphony moments (>3 notes)
- Add auto-scroll to UnifiedTimeline when selectedEventIndex changes
- Remove redundant timeline section header for cleaner layout
- Architecture supports future onion-view/event-analysis overlays via
  the PerformanceMomentSummary type and selectedEventIndex coupling

https://claude.ai/code/session_017GJ2qjtcQ3ARqEMxPSAsSw