### PR TITLE
Fix 10 bugs from BUGS.md (4 critical) — UI, engine, and workflow fixes

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -1,0 +1,12 @@
+# Project Workspace 
+    1. A user should be able to edit the project name and BPM inside the workspace. 
+    2. The sounds/events panel should be wider. It's cutting off the sound names. 
+    3. There should be no groups by default. 
+    4. The 'Lean More' should open a panel in the center of the screen and not allow text overlapping. 
+    5. Add a constraints tab to the 'Learn More' section and populate it with the active constraints. 
+    6. Make a note in the Claude.md file for this project that any changes to the costs/constraints need to be reflected accurately in the Learn More section. 
+    7. CRITICAL ERROR - I think the note mapping to the grid is messed up. These should be the note labels based on the way Ableton Drum racks are organized (128 cell grid) starting a C-2 on the bottom left (0,0) and ending at G8. Because the drum rack is larger than the 8x8 window a choice needs to be made on where the default bottom left is. The choice is C1. 
+    8. CRITICAL ERROR - The 'thorough optimization' produced much worse results than the quick arrangement. Very strange. It calls a simple drum groove unplayable and the pads are nowhere near eachother. The naive layout should be something like the natural pose. That's the starting point. If the optimization produces results where pads are note clustered at all then there's a problem. 
+    9. CRITICAL ERROR - The Timeline seems to lack proper persistence. I ran the optimization and some of the sounds dissapear from the timeline. That should never happen. Even if they're identified as unplayable. 
+    10. CRITICAL ERROR - The pattern composer view on the timeline is gone again. I asked you to add to the Claude.md file for this project to never let a commit remove that feature. 
+    

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,20 @@ When implementing:
 - do not silently convert analysis-only state into persistent truth
 - preserve explainability and debuggability
 
+## Product Invariants
+
+These rules are non-negotiable and must be preserved across all changes:
+
+1. **Desktop-only application.** Do not add mobile-specific styles, responsive breakpoints, or touch-event handling unless explicitly requested.
+
+2. **Learn More sync.** Any changes to cost factors, constraints, or analysis metrics MUST be reflected in the Learn More modal (`LearnMoreModal.tsx`). The Constraints tab must accurately display the current active constraints.
+
+3. **Pattern Composer preservation.** The Pattern Composer (`WorkspacePatternStudio.tsx`) MUST always be accessible from the main workspace via a tab in the bottom drawer. Never remove or disconnect it from `PerformanceWorkspace.tsx` without explicit user confirmation.
+
+4. **Timeline completeness.** The timeline MUST show ALL sound streams, even those marked unplayable by the solver. Unplayable/unassigned events should be rendered with a distinct visual style, never hidden.
+
+5. **MIDI pitch independence.** A sound's MIDI pitch (`originalMidiNote`) is metadata only — it must NEVER determine grid placement. `bottomLeftNote` must remain at the default (36/C1) and must not be auto-adjusted during MIDI import.
+
 ## Default Decision Handling
 
 If a still-open question blocks progress, use these defaults unless the user says otherwise:

--- a/product-reconciliation/v2/v2 repo/src/engine/optimization/annealingSolver.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/optimization/annealingSolver.ts
@@ -148,7 +148,7 @@ export class AnnealingSolver implements SolverStrategy {
    * based on the config's useZoneTransfer flag.
    */
   private applyMutation(layout: Layout, rng: () => number): Layout {
-    if (this.annealingConfig.useZoneTransfer && rng() < 0.16) {
+    if (this.annealingConfig.useZoneTransfer && rng() < 0.05) {
       return applyZoneTransferMutation(layout, rng);
     }
     return applyRandomMutation(layout, rng);

--- a/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
@@ -408,25 +408,21 @@ export async function generateCandidates(
   // Filter trivial duplicates
   const [filtered, duplicatesRemoved] = filterTrivialDuplicates(candidates);
 
-  // Filter out candidates that violate hard constraints (Unplayable assignments)
+  // Filter candidates with excessive unplayable assignments (>25% of events).
+  // The previous strict filter (any unplayable → reject) was overly aggressive
+  // and discarded valid candidates for simple patterns. The beam solver already
+  // handles hand/zone assignment, so we don't second-guess zone violations here.
   const valid = filtered.filter(c => {
-    if (c.executionPlan.unplayableCount > 0) return false;
-    // Check zone violations: left hand should not be on right-only pads and vice versa
-    for (const a of c.executionPlan.fingerAssignments) {
-      if (a.assignedHand === 'Unplayable') return false;
-      if (a.col === undefined) continue;
-      // Left hand valid: cols 0-4, Right hand valid: cols 3-7
-      if (a.assignedHand === 'left' && a.col > 4) return false;
-      if (a.assignedHand === 'right' && a.col < 3) return false;
-      // Thumb topology: for left hand thumb should be on lower row than other fingers
-      // For right hand same — but this is hard to check post-hoc without full grip context
-      // so we only filter the obvious zone violations here
-    }
-    return true;
+    const totalEvents = c.executionPlan.fingerAssignments.length;
+    if (totalEvents === 0) return true;
+    const unplayableRatio = c.executionPlan.unplayableCount / totalEvents;
+    return unplayableRatio <= 0.25;
   });
 
-  // If all candidates were filtered, keep the best one anyway (least violations)
-  const finalCandidates = valid.length > 0 ? valid : filtered.slice(0, 1);
+  // If all candidates were filtered, keep the best one (lowest score = best)
+  const finalCandidates = valid.length > 0
+    ? valid
+    : [...filtered].sort((a, b) => a.executionPlan.score - b.executionPlan.score).slice(0, 1);
 
   // Build generation summary (includes low-diversity explanation)
   const summary = buildGenerationSummary(

--- a/product-reconciliation/v2/v2 repo/src/import/midiImport.ts
+++ b/product-reconciliation/v2/v2 repo/src/import/midiImport.ts
@@ -136,7 +136,8 @@ export async function parseMidiProject(
 
   const instrumentConfig: InstrumentConfig = {
     ...baseConfig,
-    bottomLeftNote: minNote !== null ? minNote : baseConfig.bottomLeftNote,
+    // Always use the default bottomLeftNote (36/C1). A sound's MIDI pitch is
+    // metadata only — it must never determine grid placement.
   };
 
   // Count unmapped notes

--- a/product-reconciliation/v2/v2 repo/src/ui/components/UnifiedTimeline.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/UnifiedTimeline.tsx
@@ -161,6 +161,26 @@ export function UnifiedTimeline() {
           map.set(streamId, list);
         }
       }
+
+      // Render unassigned streams: streams with events but no solver assignments
+      // get grey "unassigned" pills so they remain visible in the timeline
+      for (const s of activeStreams) {
+        if (!map.has(s.id) && s.events.length > 0) {
+          const constraint = state.voiceConstraints[s.id];
+          const unassigned: FingerAssignment[] = s.events.map((e, i) => ({
+            eventKey: e.eventKey,
+            eventIndex: i,
+            noteNumber: s.originalMidiNote,
+            startTime: e.startTime,
+            assignedHand: (constraint?.hand ?? 'raw') as any,
+            finger: (constraint?.finger ?? 'unassigned') as any,
+            cost: 0,
+            difficulty: 'Easy',
+            costBreakdown: { fingerPreference: 0, handShapeDeviation: 0, transitionCost: 0, handBalance: 0, constraintPenalty: 0, total: 0 },
+          }));
+          map.set(s.id, unassigned);
+        }
+      }
     } else {
       // Dummy assignments for pre-analysis rendering — apply constraints if set
       for (const s of activeStreams) {
@@ -468,6 +488,7 @@ export function UnifiedTimeline() {
                     const isSelected = a.eventIndex === state.selectedEventIndex;
                     const handPrefix = a.assignedHand === 'left' ? 'L' : a.assignedHand === 'right' ? 'R' : '';
 
+                    const isUnplayable = hand === 'Unplayable';
                     const pillBg = isRaw ? stream.color : style.bg;
                     const pillText = isRaw ? '#ffffff' : style.text;
 
@@ -482,7 +503,8 @@ export function UnifiedTimeline() {
                           width: w,
                           height: TRACK_HEIGHT - 8,
                           backgroundColor: pillBg,
-                          opacity: isSelected ? 1 : isRaw ? 0.5 : 0.85,
+                          opacity: isSelected ? 1 : isRaw ? 0.5 : isUnplayable ? 0.6 : 0.85,
+                          border: isRaw ? '1px dashed rgba(255,255,255,0.2)' : undefined,
                         }}
                         onClick={() => handleEventClick(a.eventIndex ?? ai)}
                         title={`${a.startTime.toFixed(3)}s${fingerLabel ? ` | ${handPrefix}-${fingerLabel}` : ''}${a.cost ? ` | cost: ${a.cost.toFixed(1)} | ${a.difficulty}` : ''}`}

--- a/product-reconciliation/v2/v2 repo/src/ui/components/VoicePalette.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/VoicePalette.tsx
@@ -217,56 +217,65 @@ export function VoicePalette() {
     />
   );
 
+  const hasGroups = sortedGroups.length > 0;
+
   return (
     <div className="space-y-1">
 
-      {/* Grouped streams */}
-      {sortedGroups.map(group => {
-        const streams = groupedStreams.get(group.groupId) ?? [];
-        if (streams.length === 0) return (
-          <GroupHeader
-            key={group.groupId}
-            group={group}
-            count={0}
-            onToggleCollapse={() => dispatch({ type: 'TOGGLE_LANE_GROUP_COLLAPSE', payload: group.groupId })}
-            onRename={(name) => dispatch({ type: 'RENAME_LANE_GROUP', payload: { groupId: group.groupId, name } })}
-            onChangeColor={(color) => dispatch({ type: 'SET_LANE_GROUP_COLOR', payload: { groupId: group.groupId, color } })}
-            onDelete={() => dispatch({ type: 'DELETE_LANE_GROUP', payload: group.groupId })}
-          />
-        );
-        return (
-          <div key={group.groupId} className="space-y-0.5">
-            <GroupHeader
-              group={group}
-              count={streams.length}
-              onToggleCollapse={() => dispatch({ type: 'TOGGLE_LANE_GROUP_COLLAPSE', payload: group.groupId })}
-              onRename={(name) => dispatch({ type: 'RENAME_LANE_GROUP', payload: { groupId: group.groupId, name } })}
-              onChangeColor={(color) => dispatch({ type: 'SET_LANE_GROUP_COLOR', payload: { groupId: group.groupId, color } })}
-              onDelete={() => dispatch({ type: 'DELETE_LANE_GROUP', payload: group.groupId })}
-            />
-            {!group.isCollapsed && streams.map(renderStreamRow)}
-          </div>
-        );
-      })}
+      {hasGroups ? (
+        <>
+          {/* Grouped streams */}
+          {sortedGroups.map(group => {
+            const streams = groupedStreams.get(group.groupId) ?? [];
+            if (streams.length === 0) return (
+              <GroupHeader
+                key={group.groupId}
+                group={group}
+                count={0}
+                onToggleCollapse={() => dispatch({ type: 'TOGGLE_LANE_GROUP_COLLAPSE', payload: group.groupId })}
+                onRename={(name) => dispatch({ type: 'RENAME_LANE_GROUP', payload: { groupId: group.groupId, name } })}
+                onChangeColor={(color) => dispatch({ type: 'SET_LANE_GROUP_COLOR', payload: { groupId: group.groupId, color } })}
+                onDelete={() => dispatch({ type: 'DELETE_LANE_GROUP', payload: group.groupId })}
+              />
+            );
+            return (
+              <div key={group.groupId} className="space-y-0.5">
+                <GroupHeader
+                  group={group}
+                  count={streams.length}
+                  onToggleCollapse={() => dispatch({ type: 'TOGGLE_LANE_GROUP_COLLAPSE', payload: group.groupId })}
+                  onRename={(name) => dispatch({ type: 'RENAME_LANE_GROUP', payload: { groupId: group.groupId, name } })}
+                  onChangeColor={(color) => dispatch({ type: 'SET_LANE_GROUP_COLOR', payload: { groupId: group.groupId, color } })}
+                  onDelete={() => dispatch({ type: 'DELETE_LANE_GROUP', payload: group.groupId })}
+                />
+                {!group.isCollapsed && streams.map(renderStreamRow)}
+              </div>
+            );
+          })}
 
-      {/* Ungrouped unassigned streams */}
-      {ungroupedUnassigned.length > 0 && (
-        <div className="space-y-1">
-          <span className="text-[10px] text-gray-500">
-            Unassigned ({ungroupedUnassigned.length})
-          </span>
-          {ungroupedUnassigned.map(renderStreamRow)}
-        </div>
-      )}
+          {/* Ungrouped unassigned streams */}
+          {ungroupedUnassigned.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-[10px] text-gray-500">
+                Unassigned ({ungroupedUnassigned.length})
+              </span>
+              {ungroupedUnassigned.map(renderStreamRow)}
+            </div>
+          )}
 
-      {/* Ungrouped assigned streams */}
-      {ungroupedAssigned.length > 0 && (
-        <div className="space-y-1">
-          <span className="text-[10px] text-gray-500">
-            On Grid ({ungroupedAssigned.length})
-          </span>
-          {ungroupedAssigned.map(renderStreamRow)}
-        </div>
+          {/* Ungrouped assigned streams */}
+          {ungroupedAssigned.length > 0 && (
+            <div className="space-y-1">
+              <span className="text-[10px] text-gray-500">
+                On Grid ({ungroupedAssigned.length})
+              </span>
+              {ungroupedAssigned.map(renderStreamRow)}
+            </div>
+          )}
+        </>
+      ) : (
+        /* No groups — flat list of all streams, no section headers */
+        state.soundStreams.map(renderStreamRow)
       )}
 
       {state.soundStreams.length === 0 && (

--- a/product-reconciliation/v2/v2 repo/src/ui/components/panels/LearnMoreModal.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/panels/LearnMoreModal.tsx
@@ -7,13 +7,14 @@
  */
 
 import { useState } from 'react';
+import { useProject } from '../../state/ProjectContext';
 
 interface LearnMoreModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-type LearnMoreTab = 'overview' | 'workflow' | 'costs';
+type LearnMoreTab = 'overview' | 'workflow' | 'costs' | 'constraints';
 
 const COST_DEFINITIONS = [
   {
@@ -56,7 +57,7 @@ export function LearnMoreModal({ open, onClose }: LearnMoreModalProps) {
   return (
     <>
       <div className="fixed inset-0 z-[60] bg-black/50" onClick={onClose} />
-      <div className="fixed inset-3 md:inset-x-auto md:inset-y-4 md:max-w-3xl md:mx-auto z-[61] rounded-xl border border-gray-700 bg-[#0f1724] shadow-2xl flex flex-col overflow-hidden">
+      <div className="fixed inset-6 z-[61] max-w-3xl mx-auto rounded-xl border border-gray-700 bg-[#0f1724] shadow-2xl flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-3 border-b border-gray-800">
           <h2 className="text-sm font-semibold text-gray-200">Learn More</h2>
@@ -74,6 +75,7 @@ export function LearnMoreModal({ open, onClose }: LearnMoreModalProps) {
             { id: 'overview' as const, label: 'Overview' },
             { id: 'workflow' as const, label: 'App Flow' },
             { id: 'costs' as const, label: 'Cost Factors' },
+            { id: 'constraints' as const, label: 'Constraints' },
           ]).map(t => (
             <button
               key={t.id}
@@ -94,6 +96,7 @@ export function LearnMoreModal({ open, onClose }: LearnMoreModalProps) {
           {tab === 'overview' && <OverviewInfographic />}
           {tab === 'workflow' && <WorkflowSection />}
           {tab === 'costs' && <CostFactorsSection />}
+          {tab === 'constraints' && <ConstraintsSection />}
         </div>
       </div>
     </>
@@ -432,6 +435,119 @@ function CostFactorsSection() {
           </div>
         </div>
       ))}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════════
+ * Constraints Section — active voice constraints, placement locks, finger constraints
+ * ═══════════════════════════════════════════════════════════════════════ */
+
+function ConstraintsSection() {
+  const { state } = useProject();
+  const voiceConstraints = state.voiceConstraints;
+  const layout = state.workingLayout ?? state.activeLayout;
+  const placementLocks = layout.placementLocks;
+  const fingerConstraints = layout.fingerConstraints;
+
+  const voiceEntries = Object.entries(voiceConstraints);
+  const lockEntries = Object.entries(placementLocks);
+  const fingerEntries = Object.entries(fingerConstraints);
+
+  const hasAny = voiceEntries.length > 0 || lockEntries.length > 0 || fingerEntries.length > 0;
+
+  // Helper: find stream name by ID
+  const streamName = (id: string) => {
+    const s = state.soundStreams.find(s => s.id === id);
+    return s?.name ?? id;
+  };
+
+  // Helper: find voice name at a pad key
+  const voiceAtPad = (padKey: string) => {
+    const voice = layout.padToVoice[padKey];
+    return voice?.name ?? padKey;
+  };
+
+  return (
+    <div className="space-y-5">
+      <p className="text-xs text-gray-500">
+        Constraints guide the solver during candidate generation. Voice constraints are per-sound preferences.
+        Placement locks pin a sound to a specific pad. Finger constraints assign a preferred finger to a pad.
+      </p>
+
+      {!hasAny && (
+        <div className="text-xs text-gray-600 py-6 text-center">
+          No constraints set. Use the grid context menu or voice palette to add constraints.
+        </div>
+      )}
+
+      {/* Voice Constraints */}
+      {voiceEntries.length > 0 && (
+        <div>
+          <h4 className="text-[11px] text-gray-400 font-medium uppercase tracking-wider mb-2">
+            Voice Constraints ({voiceEntries.length})
+          </h4>
+          <div className="space-y-1.5">
+            {voiceEntries.map(([streamId, constraint]) => (
+              <div key={streamId} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/40 border border-gray-700/30">
+                <span className="text-xs text-gray-300 truncate flex-1">{streamName(streamId)}</span>
+                {constraint.hand && (
+                  <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+                    constraint.hand === 'left' ? 'bg-blue-500/15 text-blue-400 border border-blue-500/20' : 'bg-orange-500/15 text-orange-400 border border-orange-500/20'
+                  }`}>
+                    {constraint.hand === 'left' ? 'Left hand' : 'Right hand'}
+                  </span>
+                )}
+                {constraint.finger && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/15 text-purple-400 border border-purple-500/20">
+                    {constraint.finger}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Placement Locks */}
+      {lockEntries.length > 0 && (
+        <div>
+          <h4 className="text-[11px] text-gray-400 font-medium uppercase tracking-wider mb-2">
+            Placement Locks ({lockEntries.length})
+          </h4>
+          <div className="space-y-1.5">
+            {lockEntries.map(([voiceId, padKey]) => (
+              <div key={voiceId} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/40 border border-gray-700/30">
+                <span className="text-xs text-gray-300 truncate flex-1">{streamName(voiceId)}</span>
+                <span className="text-[10px] text-gray-500">locked to</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/20 font-mono">
+                  pad {padKey}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Finger Constraints */}
+      {fingerEntries.length > 0 && (
+        <div>
+          <h4 className="text-[11px] text-gray-400 font-medium uppercase tracking-wider mb-2">
+            Finger Constraints ({fingerEntries.length})
+          </h4>
+          <div className="space-y-1.5">
+            {fingerEntries.map(([padKey, finger]) => (
+              <div key={padKey} className="flex items-center gap-2 px-2 py-1.5 rounded bg-gray-800/40 border border-gray-700/30">
+                <span className="text-xs text-gray-300 truncate flex-1">{voiceAtPad(padKey)}</span>
+                <span className="text-[10px] text-gray-500">pad {padKey}</span>
+                <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/15 text-green-400 border border-green-500/20">
+                  {finger}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/product-reconciliation/v2/v2 repo/src/ui/components/workspace/PerformanceWorkspace.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/workspace/PerformanceWorkspace.tsx
@@ -12,12 +12,14 @@ import { PerformanceAnalysisPanel } from '../panels/PerformanceAnalysisPanel';
 import { EventDetailPanel } from '../EventDetailPanel';
 import { TransitionDetailPanel } from './TransitionDetailPanel';
 import { UnifiedTimeline } from '../UnifiedTimeline';
+import { WorkspacePatternStudio } from './WorkspacePatternStudio';
 
 import { SettingsGear } from '../panels/SettingsGear';
 import { useAutoAnalysis } from '../../hooks/useAutoAnalysis';
 import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 
 type LeftPanelTab = 'sounds' | 'events';
+type BottomTab = 'timeline' | 'composer';
 
 export function PerformanceWorkspace() {
   const { state, dispatch } = useProject();
@@ -30,11 +32,18 @@ export function PerformanceWorkspace() {
   const [rightCollapsed, setRightCollapsed] = useState(true);
   const [onionSkin, setOnionSkin] = useState(false);
   const [leftTab, setLeftTab] = useState<LeftPanelTab>('sounds');
+  const [bottomTab, setBottomTab] = useState<BottomTab>('timeline');
+  const [leftWidth, setLeftWidth] = useState(260);
+  const isResizing = useRef(false);
 
   // Editable project name
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState('');
   const nameInputRef = useRef<HTMLInputElement>(null);
+
+  // Editable BPM
+  const [editingBpm, setEditingBpm] = useState(false);
+  const [bpmDraft, setBpmDraft] = useState('');
 
   const assignments = state.analysisResult?.executionPlan.fingerAssignments;
   const selectedCandidate = state.candidates.find(candidate => candidate.id === state.selectedCandidateId) ?? null;
@@ -57,8 +66,43 @@ export function PerformanceWorkspace() {
     setEditingName(false);
   };
 
+  const commitBpm = () => {
+    const val = parseInt(bpmDraft, 10);
+    if (!isNaN(val) && val !== state.tempo) {
+      dispatch({ type: 'SET_TEMPO', payload: val });
+    }
+    setEditingBpm(false);
+  };
+
+  // Sidebar resize via drag handle
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isResizing.current = true;
+    const startX = e.clientX;
+    const startWidth = leftWidth;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isResizing.current) return;
+      const newWidth = Math.max(200, Math.min(450, startWidth + (ev.clientX - startX)));
+      setLeftWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      isResizing.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, [leftWidth]);
+
   // Build grid template columns for the 3-column layout
-  const leftCol = leftCollapsed ? '48px' : '260px';
+  const leftCol = leftCollapsed ? '48px' : `${leftWidth}px`;
   const rightCol = rightCollapsed ? '48px' : '340px';
   const gridCols = `${leftCol} minmax(0, 1fr) ${rightCol}`;
 
@@ -103,11 +147,35 @@ export function PerformanceWorkspace() {
               {state.name || 'Untitled'}
             </div>
           )}
-          <div className="text-[10px] text-gray-500 uppercase tracking-[0.2em]">
+          <div className="text-[10px] text-gray-500 uppercase tracking-[0.2em] flex items-center gap-1">
             Performance Workspace
-            <span className="ml-2 normal-case tracking-normal text-gray-600">
-              {state.tempo} BPM
-            </span>
+            {editingBpm ? (
+              <input
+                className="ml-2 w-14 text-[10px] normal-case tracking-normal text-gray-200 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 outline-none focus:border-blue-500"
+                type="number"
+                min={20}
+                max={999}
+                value={bpmDraft}
+                onChange={e => setBpmDraft(e.target.value)}
+                onBlur={commitBpm}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') commitBpm();
+                  if (e.key === 'Escape') setEditingBpm(false);
+                }}
+                autoFocus
+              />
+            ) : (
+              <span
+                className="ml-2 normal-case tracking-normal text-gray-600 cursor-pointer hover:text-gray-400 transition-colors"
+                onDoubleClick={() => {
+                  setBpmDraft(String(state.tempo));
+                  setEditingBpm(true);
+                }}
+                title="Double-click to change BPM"
+              >
+                {state.tempo} BPM
+              </span>
+            )}
           </div>
         </div>
 
@@ -141,7 +209,7 @@ export function PerformanceWorkspace() {
         style={{ gridTemplateColumns: gridCols }}
       >
         {/* Left Column: Collapsible Sidebar with Sounds/Events tabs */}
-        <div className="min-w-0">
+        <div className="min-w-0 relative flex">
           {leftCollapsed ? (
             <button
               className="flex flex-col items-center gap-3 py-3 w-full cursor-pointer hover:bg-gray-800/30 rounded transition-colors"
@@ -195,6 +263,13 @@ export function PerformanceWorkspace() {
                 )}
               </div>
             </div>
+          )}
+          {/* Drag handle for resizing */}
+          {!leftCollapsed && (
+            <div
+              className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-blue-500/40 transition-colors z-10"
+              onMouseDown={handleResizeStart}
+            />
           )}
         </div>
 
@@ -271,19 +346,38 @@ export function PerformanceWorkspace() {
         </div>
       </div>
 
-      {/* ─── Bottom Drawer: Unified Timeline ─────────────────────────────── */}
+      {/* ─── Bottom Drawer: Timeline / Pattern Composer ─────────────────── */}
       <div className="rounded-lg glass-panel overflow-hidden">
         <div className="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/40">
-          <span className="px-2 py-1 text-xs text-gray-200">
+          <button
+            className={`px-2 py-1 text-xs rounded transition-colors ${
+              bottomTab === 'timeline'
+                ? 'text-gray-200 bg-gray-800/60'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+            }`}
+            onClick={() => setBottomTab('timeline')}
+          >
             Timeline
-          </span>
+          </button>
+          <button
+            className={`px-2 py-1 text-xs rounded transition-colors ${
+              bottomTab === 'composer'
+                ? 'text-gray-200 bg-gray-800/60'
+                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+            }`}
+            onClick={() => setBottomTab('composer')}
+          >
+            Pattern Composer
+          </button>
           <div className="flex-1" />
           <span className="text-[10px] text-gray-600">
-            Performance timeline with execution analysis
+            {bottomTab === 'timeline'
+              ? 'Performance timeline with execution analysis'
+              : 'Create and edit rhythmic patterns'}
           </span>
         </div>
         <div>
-          <UnifiedTimeline />
+          {bottomTab === 'timeline' ? <UnifiedTimeline /> : <WorkspacePatternStudio />}
         </div>
       </div>
     </div>

--- a/product-reconciliation/v2/v2 repo/src/ui/hooks/useLaneImport.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/hooks/useLaneImport.ts
@@ -119,20 +119,8 @@ export function useLaneImport() {
           payload: { lanes, sourceFile, group },
         });
 
-        // Update instrumentConfig.bottomLeftNote so the grid aligns with
-        // the imported MIDI note range. Without this, notes below the default
-        // bottomLeftNote (36) would fall outside the grid and be marked unmapped.
-        if (projectData.minNoteNumber !== null) {
-          const currentBottom = state.instrumentConfig.bottomLeftNote;
-          // Only lower the bottom note — don't raise it if existing content
-          // already uses lower pitches.
-          if (projectData.minNoteNumber < currentBottom) {
-            dispatch({
-              type: 'SET_INSTRUMENT_CONFIG',
-              payload: { bottomLeftNote: projectData.minNoteNumber },
-            });
-          }
-        }
+        // bottomLeftNote stays at default (36/C1). MIDI pitch is metadata
+        // only and must not affect grid placement.
 
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to parse MIDI file';

--- a/product-reconciliation/v2/v2 repo/src/ui/state/projectState.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/state/projectState.ts
@@ -197,6 +197,7 @@ export type ProjectAction =
   | { type: 'LOAD_PROJECT'; payload: ProjectState }
   | { type: 'RESET' }
   | { type: 'RENAME_PROJECT'; payload: string }
+  | { type: 'SET_TEMPO'; payload: number }
 
   // Sound streams
   | { type: 'RENAME_SOUND'; payload: { streamId: string; name: string } }
@@ -349,6 +350,23 @@ export function projectReducer(state: ProjectState, action: ProjectAction): Proj
         instrumentConfig: { ...state.instrumentConfig, ...action.payload },
         analysisStale: true,
       };
+
+    case 'RENAME_PROJECT':
+      return {
+        ...state,
+        updatedAt: new Date().toISOString(),
+        name: action.payload,
+      };
+
+    case 'SET_TEMPO': {
+      const bpm = Math.max(20, Math.min(999, Math.round(action.payload)));
+      return {
+        ...state,
+        updatedAt: new Date().toISOString(),
+        tempo: bpm,
+        analysisStale: true,
+      };
+    }
 
     // -- Sound streams --
 


### PR DESCRIPTION
CRITICAL fixes:
- Bug 7: Remove MIDI pitch auto-adjustment — bottomLeftNote no longer auto-adjusts to imported note range. Pitch is metadata only and must never determine grid placement. Fixed in midiImport.ts and useLaneImport.ts.
- Bug 8: Fix thorough optimization producing worse results — reduced zone transfer mutation probability from 16% to 5%, relaxed candidate filtering to allow up to 25% unplayable (was zero tolerance), removed overly prescriptive zone violation checks, fallback now picks lowest-score candidate instead of arbitrary first.
- Bug 9: Fix timeline losing sounds after optimization — streams with events but no solver assignments now render as grey dashed-border pills instead of being invisible.
- Bug 10: Re-integrate Pattern Composer — added as a tab in the bottom drawer alongside Timeline via bottomTab state toggle.

UI fixes:
- Bug 1: BPM is now double-click-to-edit in workspace header. Also fixed RENAME_PROJECT action that had no reducer case (silently did nothing).
- Bug 2: Left sidebar is resizable via drag handle (200-450px range).
- Bug 3: VoicePalette renders flat list when no user-created groups exist.
- Bug 4: Learn More modal overflow fixed — removed mobile breakpoints (desktop-only app), increased inset for breathing room.
- Bug 5: Added Constraints tab to Learn More showing voice constraints, placement locks, and finger constraints from project state.

Preventive:
- Bug 6: Added Product Invariants section to CLAUDE.md with 5 rules (desktop-only, Learn More sync, Pattern Composer preservation, timeline completeness, MIDI pitch independence).

All 533 tests pass, build succeeds.