### PR TITLE
Fix all events unplayable bug, remove homepage MIDI import

### DIFF
--- a/product-reconciliation/v2/v2 repo/.claude/launch.json
+++ b/product-reconciliation/v2/v2 repo/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/optimization/multiCandidateGenerator.ts
@@ -35,7 +35,7 @@ import {
 import { type Section } from '../../types/performanceStructure';
 import { type FingerType } from '../../types/fingerModel';
 import { seedLayoutFromPose0 } from '../mapping/seedFromPose';
-import { getMaxSafeOffset, poseHasAssignments } from '../prior/naturalHandPose';
+import { getMaxSafeOffset, poseHasAssignments, fingerIdToHandAndFingerType, getPose0PadsWithOffset } from '../prior/naturalHandPose';
 import { createAnnealingSolver } from './annealingSolver';
 import { createBeamSolver } from '../solvers/beamSolver';
 import { analyzeDifficulty, computeTradeoffProfile } from '../evaluation/difficultyScoring';
@@ -45,6 +45,42 @@ import {
   buildGenerationSummary,
 } from '../analysis/diversityMeasurement';
 import { generateId } from '../../utils/idGenerator';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Compute initial pad ownership from pose0 + layout.
+ * For each pad in the layout that corresponds to a pose0 finger position,
+ * pre-assign the natural finger. This prevents the solver from picking
+ * a random finger for the first hit and locking a sub-optimal assignment.
+ */
+function computeInitialPadOwnership(
+  pose0: NaturalHandPose,
+  layout: Layout,
+  offsetRow: number = 0,
+): Record<string, { hand: 'left' | 'right'; finger: FingerType }> {
+  const ownership: Record<string, { hand: 'left' | 'right'; finger: FingerType }> = {};
+  const posePads = getPose0PadsWithOffset(pose0, offsetRow, true);
+
+  // Build a map of pad position → fingerId from pose0
+  const padToFinger = new Map<string, string>();
+  for (const entry of posePads) {
+    padToFinger.set(`${entry.row},${entry.col}`, entry.fingerId);
+  }
+
+  // For each pad in the layout, if it matches a pose0 position, assign that finger
+  for (const padKey of Object.keys(layout.padToVoice)) {
+    const fingerId = padToFinger.get(padKey);
+    if (fingerId) {
+      const { hand, finger } = fingerIdToHandAndFingerType(fingerId as import('../../types/ergonomicPrior').FingerId);
+      ownership[padKey] = { hand, finger };
+    }
+  }
+
+  return ownership;
+}
 
 // ============================================================================
 // Configuration
@@ -285,9 +321,19 @@ export async function generateCandidates(
     const ls = strategy.layoutStrategy;
 
     if (ls.type === 'pose0-offset') {
-      // Pose0-based: seed layout from natural hand pose with offset
+      // Pose0-based: seed layout from natural hand pose with offset.
+      // Extract existing voices from baseLayout to preserve voiceId chain.
+      let existingVoices: Map<number, import('../../types/voice').Voice> | undefined;
+      if (config.baseLayout) {
+        existingVoices = new Map();
+        for (const voice of Object.values(config.baseLayout.padToVoice)) {
+          if (voice.originalMidiNote != null) {
+            existingVoices.set(voice.originalMidiNote, voice);
+          }
+        }
+      }
       layout = pose0 && poseHasAssignments(pose0)
-        ? seedLayoutFromPose0(performance, pose0, ls.offsetRow)
+        ? seedLayoutFromPose0(performance, pose0, ls.offsetRow, existingVoices)
         : config.baseLayout ?? {
             id: generateId('layout'),
             name: `Generated Layout (${strategy.name})`,
@@ -351,10 +397,23 @@ export async function generateCandidates(
       finalLayout = solver.getBestLayout() ?? layout;
     } else {
       // Run beam search only (no annealing requested or empty layout)
+      const hasLayout = Object.keys(layout.padToVoice).length > 0;
+
+      // Pre-seed pad ownership from pose0 when available — this ensures the
+      // solver uses the natural finger for each pad from the first event,
+      // preventing ownership conflicts from random grip selection.
+      const offsetRow = strategy.layoutStrategy.type === 'pose0-offset'
+        ? strategy.layoutStrategy.offsetRow
+        : 0;
+      const initialPadOwnership = (pose0 && poseHasAssignments(pose0) && hasLayout)
+        ? computeInitialPadOwnership(pose0, layout, offsetRow)
+        : undefined;
+
       const solverConfig: SolverConfig = {
         instrumentConfig: config.instrumentConfig,
-        layout: Object.keys(layout.padToVoice).length > 0 ? layout : null,
+        layout: hasLayout ? layout : null,
         mappingResolverMode: 'allow-fallback',
+        initialPadOwnership,
       };
       const solver = createBeamSolver(solverConfig);
       executionPlan = await solver.solve(performance, candidateEngineConfig, config.manualAssignments);

--- a/product-reconciliation/v2/v2 repo/src/engine/prior/naturalHandPose.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/prior/naturalHandPose.ts
@@ -92,14 +92,24 @@ export function validateNaturalHandPose(pose: NaturalHandPose): PoseValidationRe
 // Default Pose Factory
 // ============================================================================
 
-/** Built-in default Pose 0 positions. */
+/**
+ * Built-in default Pose 0 positions.
+ *
+ * All fingers within a 2-row vertical spread so simultaneous grips are
+ * biomechanically feasible. Thumb sits one row above the index finger
+ * (adjacent) rather than at the grid edge, preventing unreachable
+ * multi-finger chords.
+ *
+ * Left hand cluster: cols 0-3, rows 2-4
+ * Right hand cluster: cols 4-7, rows 2-4
+ */
 const BUILT_IN_POSE0_CELLS: Record<FingerId, PadCoord> = {
-  L_THUMB: { row: 0, col: 3 },
+  L_THUMB: { row: 2, col: 3 },
   L_INDEX: { row: 3, col: 3 },
   L_MIDDLE: { row: 4, col: 2 },
   L_RING: { row: 4, col: 1 },
   L_PINKY: { row: 4, col: 0 },
-  R_THUMB: { row: 0, col: 4 },
+  R_THUMB: { row: 2, col: 4 },
   R_INDEX: { row: 3, col: 4 },
   R_MIDDLE: { row: 4, col: 5 },
   R_RING: { row: 4, col: 6 },

--- a/product-reconciliation/v2/v2 repo/src/engine/solvers/beamSolver.ts
+++ b/product-reconciliation/v2/v2 repo/src/engine/solvers/beamSolver.ts
@@ -31,7 +31,7 @@ import {
 } from '../../types/executionPlan';
 import { MOMENT_EPSILON } from '../../types/performanceEvent';
 import { buildNoteToPadIndex, buildVoiceIdToPadIndex, resolveEventToPad, hashLayout } from '../mapping/mappingResolver';
-import { allPadsInZone } from '../surface/handZone';
+import { allPadsInZone, isZoneValid } from '../surface/handZone';
 import { generateValidGripsWithTier } from '../prior/feasibility';
 import {
   calculateHandShapeDeviation,
@@ -185,6 +185,7 @@ export class BeamSolver implements SolverStrategy {
   private sourceLayoutRole: import('../../types/layout').LayoutRole | undefined;
   private neutralPadPositionsOverride: NeutralPadPositions | null;
   private mappingResolverMode: 'strict' | 'allow-fallback';
+  private initialPadOwnership: Map<string, { hand: 'left' | 'right'; finger: FingerType }>;
 
   constructor(config: SolverConfig) {
     this.instrumentConfig = config.instrumentConfig;
@@ -192,6 +193,14 @@ export class BeamSolver implements SolverStrategy {
     this.sourceLayoutRole = config.sourceLayoutRole ?? config.layout?.role;
     this.neutralPadPositionsOverride = config.neutralPadPositionsOverride ?? null;
     this.mappingResolverMode = config.mappingResolverMode ?? 'strict';
+
+    // Pre-seed pad ownership from config (e.g., natural hand pose finger assignments)
+    this.initialPadOwnership = new Map();
+    if (config.initialPadOwnership) {
+      for (const [key, assignment] of Object.entries(config.initialPadOwnership)) {
+        this.initialPadOwnership.set(key, assignment);
+      }
+    }
   }
 
   private createInitialBeam(config: EngineConfiguration): BeamNode[] {
@@ -205,7 +214,7 @@ export class BeamSolver implements SolverStrategy {
       depth: 0,
       leftCount: 0,
       rightCount: 0,
-      padOwnership: new Map(),
+      padOwnership: new Map(this.initialPadOwnership),
     }];
   }
 
@@ -645,6 +654,100 @@ export class BeamSolver implements SolverStrategy {
     return path;
   }
 
+  /**
+   * Post-hoc diagnostics: for each unplayable event, determine WHY it failed.
+   * Runs after the beam search completes, checking the same constraints the
+   * solver uses but collecting rejection reasons instead of discarding.
+   */
+  private diagnoseUnplayableEvents(
+    assignments: NoteAssignment[],
+    totalEvents: number,
+    unmappedIndices: Set<number>,
+    _sortedEvents: Array<{ event: PerformanceEvent; originalIndex: number }>,
+    eventsWithPositions: Array<{ event: PerformanceEvent; index: number; position: PadCoord | null }>,
+    groups?: PerformanceGroup[],
+    exhaustedGroupIndices?: Set<number>,
+  ): Record<number, string[]> {
+    const assignedIndices = new Set(assignments.map(a => a.eventIndex));
+    const reasons: Record<number, string[]> = {};
+
+    // Build a set of event indices that belonged to beam-exhausted groups
+    const beamExhaustedEventIndices = new Set<number>();
+    if (groups && exhaustedGroupIndices) {
+      for (const gi of exhaustedGroupIndices) {
+        const group = groups[gi];
+        for (const idx of group.eventIndices) {
+          beamExhaustedEventIndices.add(idx);
+        }
+      }
+    }
+
+    for (let i = 0; i < totalEvents; i++) {
+      // Skip events that were successfully assigned
+      if (assignedIndices.has(i)) continue;
+
+      const eventReasons: string[] = [];
+
+      if (unmappedIndices.has(i)) {
+        eventReasons.push('unmapped');
+      } else if (beamExhaustedEventIndices.has(i)) {
+        // This event was in a group where beam expansion produced zero children.
+        // Do additional post-hoc checks to explain WHY the beam exhausted.
+        const ewp = eventsWithPositions.find(e => e.index === i);
+        if (ewp?.position) {
+          const pad = ewp.position;
+          const leftZone = isZoneValid(pad, 'left');
+          const rightZone = isZoneValid(pad, 'right');
+          if (!leftZone && !rightZone) {
+            eventReasons.push('zone_conflict');
+          }
+          const leftGrips = leftZone ? generateValidGripsWithTier([pad], 'left') : [];
+          const rightGrips = rightZone ? generateValidGripsWithTier([pad], 'right') : [];
+          if (leftGrips.length === 0 && rightGrips.length === 0) {
+            eventReasons.push('no_valid_grip');
+          }
+        }
+        // Always include beam_exhausted as the proximate cause
+        eventReasons.push('beam_exhausted');
+      } else {
+        // Event had a position but wasn't assigned — check why
+        const ewp = eventsWithPositions.find(e => e.index === i);
+        if (!ewp || !ewp.position) {
+          eventReasons.push('unmapped');
+        } else {
+          const pad = ewp.position;
+
+          // Check zone: is this pad reachable by at least one hand?
+          const leftZone = isZoneValid(pad, 'left');
+          const rightZone = isZoneValid(pad, 'right');
+          if (!leftZone && !rightZone) {
+            eventReasons.push('zone_conflict');
+          }
+
+          // Check grip: can any hand form a valid grip on this pad?
+          const leftGrips = leftZone ? generateValidGripsWithTier([pad], 'left') : [];
+          const rightGrips = rightZone ? generateValidGripsWithTier([pad], 'right') : [];
+          if (leftGrips.length === 0 && rightGrips.length === 0) {
+            eventReasons.push('no_valid_grip');
+          }
+
+          // If we still haven't found a reason, it's likely a cascading
+          // beam exhaustion — the beam carried forward stale states from
+          // an earlier group failure, so this group had no viable parents.
+          if (eventReasons.length === 0) {
+            eventReasons.push('beam_exhausted');
+          }
+        }
+      }
+
+      if (eventReasons.length > 0) {
+        reasons[i] = eventReasons;
+      }
+    }
+
+    return reasons;
+  }
+
   private buildResult(
     assignments: NoteAssignment[],
     totalEvents: number,
@@ -653,6 +756,9 @@ export class BeamSolver implements SolverStrategy {
     sortedEvents: Array<{ event: PerformanceEvent; originalIndex: number }>,
     coverage: { totalNotes: number; unmappedNotesCount: number; fallbackNotesCount: number },
     winningPadOwnership?: Map<string, { hand: 'left' | 'right'; finger: FingerType }>,
+    eventsWithPositions?: Array<{ event: PerformanceEvent; index: number; position: PadCoord | null }>,
+    groups?: PerformanceGroup[],
+    exhaustedGroupIndices?: Set<number>,
   ): ExecutionPlanResult {
     const fingerAssignments: FingerAssignment[] = [];
     const fingerUsageStats: FingerUsageStats = {};
@@ -673,11 +779,17 @@ export class BeamSolver implements SolverStrategy {
       assignmentMap.set(assignment.eventIndex, assignment);
     }
 
+    // Build lookup from originalIndex → event for correct metadata on unplayable events
+    const eventByOriginalIndex = new Map<number, PerformanceEvent>();
+    for (const { event, originalIndex } of sortedEvents) {
+      eventByOriginalIndex.set(originalIndex, event);
+    }
+
     for (let i = 0; i < totalEvents; i++) {
       const assignment = assignmentMap.get(i);
+      const ev = eventByOriginalIndex.get(i);
 
       if (unmappedIndices.has(i)) {
-        const ev = sortedEvents[i]?.event;
         fingerAssignments.push({
           noteNumber: ev?.noteNumber ?? 0,
           voiceId: ev?.voiceId,
@@ -696,12 +808,15 @@ export class BeamSolver implements SolverStrategy {
       if (!assignment) {
         unplayableCount++;
         fingerAssignments.push({
-          noteNumber: 0, startTime: 0,
+          noteNumber: ev?.noteNumber ?? 0,
+          voiceId: ev?.voiceId,
+          startTime: ev?.startTime ?? 0,
           assignedHand: 'Unplayable', finger: null,
           cost: Infinity,
           costBreakdown: { ...createZeroV1CostBreakdown(), total: Infinity },
           difficulty: 'Unplayable',
           eventIndex: i,
+          eventKey: ev?.eventKey,
         });
         continue;
       }
@@ -872,6 +987,11 @@ export class BeamSolver implements SolverStrategy {
       });
     }
 
+    // Post-hoc diagnostics for unplayable events
+    const rejectionReasons = unplayableCount > 0 && eventsWithPositions
+      ? this.diagnoseUnplayableEvents(assignments, totalEvents, unmappedIndices, sortedEvents, eventsWithPositions, groups, exhaustedGroupIndices)
+      : undefined;
+
     return {
       score,
       unplayableCount,
@@ -891,6 +1011,7 @@ export class BeamSolver implements SolverStrategy {
         layoutRole: this.sourceLayoutRole ?? this.layout.role ?? 'active',
       } as ExecutionPlanLayoutBinding : undefined,
       diagnostics,
+      rejectionReasons,
       metadata: {
         layoutIdUsed: this.layout?.id,
         layoutHashUsed: this.layout ? hashLayout(this.layout) : undefined,
@@ -1001,6 +1122,9 @@ export class BeamSolver implements SolverStrategy {
     // Initialize beam
     let beam = this.createInitialBeam(effectiveConfig);
     let prevTimestamp = 0;
+
+    // Track which groups had beam exhaustion (no valid expansions)
+    const exhaustedGroupIndices = new Set<number>();
 
     // Process each group
     for (let gi = 0; gi < groups.length; gi++) {
@@ -1132,8 +1256,10 @@ export class BeamSolver implements SolverStrategy {
       // Events in this group become infeasible (no assignment in backtrack).
       if (newBeam.length > 0) {
         beam = this.pruneBeam(newBeam, effectiveConfig.beamWidth);
+      } else {
+        // Record which event indices had beam exhaustion
+        exhaustedGroupIndices.add(gi);
       }
-      // else: beam stays unchanged — previous nodes carry forward
       prevTimestamp = group.timestamp;
     }
 
@@ -1149,7 +1275,7 @@ export class BeamSolver implements SolverStrategy {
     };
 
     if (beam.length === 0) {
-      return this.buildResult([], performance.events.length, unmappedIndices, effectiveConfig, sortedEvents, coverage, new Map());
+      return this.buildResult([], performance.events.length, unmappedIndices, effectiveConfig, sortedEvents, coverage, new Map(), eventsWithPositions, groups, exhaustedGroupIndices);
     }
 
     const bestNode = beam.reduce((best, node) =>
@@ -1157,7 +1283,7 @@ export class BeamSolver implements SolverStrategy {
     );
 
     const assignments = this.backtrack(bestNode);
-    return this.buildResult(assignments, performance.events.length, unmappedIndices, effectiveConfig, sortedEvents, coverage, bestNode.padOwnership);
+    return this.buildResult(assignments, performance.events.length, unmappedIndices, effectiveConfig, sortedEvents, coverage, bestNode.padOwnership, eventsWithPositions, groups, exhaustedGroupIndices);
   }
 }
 

--- a/product-reconciliation/v2/v2 repo/src/types/engineConfig.ts
+++ b/product-reconciliation/v2/v2 repo/src/types/engineConfig.ts
@@ -78,6 +78,13 @@ export interface SolverConfig {
   engineConstants?: EngineConstants;
   neutralPadPositionsOverride?: NeutralPadPositions | null;
   mappingResolverMode?: 'strict' | 'allow-fallback';
+  /**
+   * Pre-seed pad ownership from the natural hand pose.
+   * When provided, the beam search starts with these finger-to-pad assignments
+   * already locked, ensuring consistent finger usage from the first event.
+   * Keys are pad coords ("row,col"), values are { hand, finger }.
+   */
+  initialPadOwnership?: Record<string, { hand: 'left' | 'right'; finger: import('./fingerModel').FingerType }>;
   seed?: number;
   annealingConfig?: AnnealingConfig;
 }

--- a/product-reconciliation/v2/v2 repo/src/types/executionPlan.ts
+++ b/product-reconciliation/v2/v2 repo/src/types/executionPlan.ts
@@ -257,6 +257,18 @@ export interface ExecutionPlanResult {
   /** Canonical diagnostics payload (Phase 3). */
   diagnostics?: DiagnosticsPayload;
 
+  /**
+   * Per-event rejection reasons explaining why events are unplayable.
+   * Keyed by event index. Values are arrays of rejection reason strings:
+   * - 'unmapped' — event couldn't be resolved to any pad position
+   * - 'zone_conflict' — pads span both zones, no single-hand or split solution
+   * - 'ownership_conflict' — pad ownership invariant rejected all grips
+   * - 'speed_limit' — hand can't move fast enough between positions
+   * - 'no_valid_grip' — no biomechanically valid finger assignment exists
+   * - 'beam_exhausted' — beam had no valid parent nodes for this group
+   */
+  rejectionReasons?: Record<number, string[]>;
+
   /** Run metadata for debugging and telemetry. */
   metadata?: {
     /** @deprecated Use layoutBinding.layoutId instead. */

--- a/product-reconciliation/v2/v2 repo/src/ui/components/Debug/LayoutDebugPanel.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/Debug/LayoutDebugPanel.tsx
@@ -1,0 +1,149 @@
+/**
+ * LayoutDebugPanel.
+ *
+ * Appears when solver results have unplayable events.
+ * Shows rejection reason breakdown and zone boundary info.
+ * Lets the user recompute after manually adjusting the grid layout.
+ */
+
+import { useState, useCallback } from 'react';
+import { useProject } from '../../state/ProjectContext';
+import { getActivePerformance, getDisplayedLayout, getActiveStreams } from '../../state/projectState';
+import { createBeamSolver } from '../../../engine/solvers/beamSolver';
+import { type SolverConfig } from '../../../types/engineConfig';
+import { type ExecutionPlanResult } from '../../../types/executionPlan';
+
+const REASON_LABELS: Record<string, string> = {
+  unmapped: 'Not mapped to any pad',
+  zone_conflict: 'Pad outside hand zone',
+  ownership_conflict: 'Finger ownership conflict',
+  speed_limit: 'Hand speed exceeded',
+  no_valid_grip: 'No valid finger grip',
+  beam_exhausted: 'No solution path found',
+};
+
+interface LayoutDebugPanelProps {
+  executionPlan: ExecutionPlanResult;
+}
+
+export function LayoutDebugPanel({ executionPlan }: LayoutDebugPanelProps) {
+  const { state, dispatch } = useProject();
+  const [recomputeResult, setRecomputeResult] = useState<ExecutionPlanResult | null>(null);
+  const [isRecomputing, setIsRecomputing] = useState(false);
+
+  const activeResult = recomputeResult ?? executionPlan;
+  const unplayableCount = activeResult.unplayableCount;
+  const totalEvents = activeResult.fingerAssignments.length;
+  const playableCount = totalEvents - unplayableCount;
+
+  // Aggregate rejection reasons
+  const reasonCounts: Record<string, number> = {};
+  if (activeResult.rejectionReasons) {
+    for (const reasons of Object.values(activeResult.rejectionReasons)) {
+      for (const r of reasons) {
+        reasonCounts[r] = (reasonCounts[r] || 0) + 1;
+      }
+    }
+  }
+
+  const handleRecompute = useCallback(async () => {
+    const layout = getDisplayedLayout(state);
+    const activeStreams = getActiveStreams(state);
+    if (!layout || activeStreams.length === 0) return;
+
+    setIsRecomputing(true);
+    try {
+      const performance = getActivePerformance(state);
+      const solverConfig: SolverConfig = {
+        instrumentConfig: state.instrumentConfig,
+        layout,
+        sourceLayoutRole: layout.role,
+        mappingResolverMode: 'allow-fallback',
+      };
+      const solver = createBeamSolver(solverConfig);
+      const result = await solver.solve(performance, state.engineConfig);
+      setRecomputeResult(result);
+
+      // Update the analysis result in state so the timeline reflects the new assignments
+      if (state.analysisResult) {
+        dispatch({
+          type: 'SET_ANALYSIS_RESULT',
+          payload: { ...state.analysisResult, executionPlan: result },
+        });
+      }
+    } catch (err) {
+      dispatch({
+        type: 'SET_ERROR',
+        payload: err instanceof Error ? err.message : 'Recompute failed',
+      });
+    } finally {
+      setIsRecomputing(false);
+    }
+  }, [state, dispatch]);
+
+  if (unplayableCount === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-medium text-red-400">
+          Debug: {unplayableCount}/{totalEvents} events unplayable
+        </h3>
+        <button
+          className={`px-2 py-1 text-[10px] rounded transition-colors ${
+            isRecomputing
+              ? 'bg-gray-700 text-gray-500 cursor-wait'
+              : 'bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-500/30'
+          }`}
+          onClick={handleRecompute}
+          disabled={isRecomputing}
+          title="Re-run solver on current pad layout to check if manual adjustments fix unplayable events"
+        >
+          {isRecomputing ? 'Recomputing...' : 'Recompute'}
+        </button>
+      </div>
+
+      {/* Playability summary bar */}
+      <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-green-500/60 transition-all"
+          style={{ width: `${(playableCount / totalEvents) * 100}%` }}
+        />
+      </div>
+      <div className="flex justify-between text-[10px] text-gray-500">
+        <span>{playableCount} playable</span>
+        <span>{unplayableCount} unplayable</span>
+      </div>
+
+      {/* Rejection reason breakdown */}
+      {Object.keys(reasonCounts).length > 0 && (
+        <div className="space-y-1">
+          <span className="text-[10px] text-gray-500 font-medium">Rejection reasons:</span>
+          {Object.entries(reasonCounts)
+            .sort((a, b) => b[1] - a[1])
+            .map(([reason, count]) => (
+              <div key={reason} className="flex items-center justify-between text-[10px]">
+                <span className="text-gray-400">{REASON_LABELS[reason] ?? reason}</span>
+                <span className="text-red-400/80 font-mono">{count}</span>
+              </div>
+            ))}
+        </div>
+      )}
+
+      {/* Zone reference */}
+      <div className="text-[10px] text-gray-600 border-t border-gray-800 pt-2">
+        <span className="font-medium text-gray-500">Hand zones: </span>
+        Left cols 0-4, Right cols 3-7, Shared cols 3-4.
+        Drag pads on the grid to adjust placement, then click Recompute.
+      </div>
+
+      {recomputeResult && (
+        <div className="text-[10px] text-gray-500 italic">
+          Showing recomputed results. {recomputeResult.unplayableCount === 0
+            ? 'All events now playable!'
+            : `Still ${recomputeResult.unplayableCount} unplayable.`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/product-reconciliation/v2/v2 repo/src/ui/components/panels/CandidatePreviewCard.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/panels/CandidatePreviewCard.tsx
@@ -99,10 +99,23 @@ export function CandidatePreviewCard({
           <span>Top: {topDriver}</span>
         </div>
 
-        {/* Feasibility warning */}
+        {/* Feasibility warning with reason summary */}
         {candidate.executionPlan.unplayableCount > 0 && (
           <div className="text-[10px] text-red-400 bg-red-500/10 rounded px-1.5 py-0.5 mb-2">
             {candidate.executionPlan.unplayableCount} unplayable
+            {candidate.executionPlan.rejectionReasons && (() => {
+              const counts: Record<string, number> = {};
+              for (const reasons of Object.values(candidate.executionPlan.rejectionReasons)) {
+                for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
+              }
+              const top = Object.entries(counts).sort((a, b) => b[1] - a[1])[0];
+              const SHORT_LABELS: Record<string, string> = {
+                unmapped: 'unmapped', zone_conflict: 'zone conflict',
+                ownership_conflict: 'ownership', speed_limit: 'speed',
+                no_valid_grip: 'no grip', beam_exhausted: 'no solution path',
+              };
+              return top ? <span className="text-red-400/60"> ({SHORT_LABELS[top[0]] ?? top[0]})</span> : null;
+            })()}
           </div>
         )}
 

--- a/product-reconciliation/v2/v2 repo/src/ui/components/panels/PerformanceAnalysisPanel.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/components/panels/PerformanceAnalysisPanel.tsx
@@ -11,12 +11,14 @@
 
 import { useState, useMemo, type ReactNode } from 'react';
 import { useProject } from '../../state/ProjectContext';
+import { type ExecutionPlanResult } from '../../../types/executionPlan';
 
 import { LearnMoreModal } from './LearnMoreModal';
 import { EventCostChart } from './EventCostChart';
 import { CostBreakdownBars } from './CostBreakdownBars';
 import { CandidatePreviewCard } from './CandidatePreviewCard';
 import { CandidateCompare } from '../CandidateCompare';
+import { LayoutDebugPanel } from '../Debug/LayoutDebugPanel';
 
 interface PerformanceAnalysisPanelProps {
   onClose: () => void;
@@ -144,6 +146,11 @@ export function PerformanceAnalysisPanel({
             </CollapsibleSection>
           )}
 
+          {/* ─── Unplayable Diagnostics ─────────────────────── */}
+          {currentPlan && currentPlan.unplayableCount > 0 && (
+            <UnplayableDiagnostics plan={currentPlan} />
+          )}
+
           {/* ─── Section 3: Compare Mode ──────────────────────── */}
           {compareMode && selectedCandidate && (
             <div className="border-b border-gray-800 pb-4 space-y-3">
@@ -234,6 +241,11 @@ export function PerformanceAnalysisPanel({
             </CollapsibleSection>
           )}
 
+          {/* Debug panel for unplayable events */}
+          {currentPlan && currentPlan.unplayableCount > 0 && (
+            <LayoutDebugPanel executionPlan={currentPlan} />
+          )}
+
           {/* Saved variants */}
           {state.savedVariants.length > 0 && (
             <div className="text-[10px] text-gray-600 pt-2 border-t border-gray-800">
@@ -264,6 +276,58 @@ export function PerformanceAnalysisPanel({
         />
       )}
     </>
+  );
+}
+
+/** Summarizes WHY events are unplayable, using solver rejection reasons. */
+function UnplayableDiagnostics({ plan }: { plan: ExecutionPlanResult }) {
+  const reasons = plan.rejectionReasons;
+  if (!reasons || Object.keys(reasons).length === 0) {
+    return (
+      <div className="p-3 rounded-lg border border-red-500/30 bg-red-500/5 text-[11px] text-red-300">
+        <div className="font-medium mb-1">{plan.unplayableCount} event{plan.unplayableCount !== 1 ? 's' : ''} unplayable</div>
+        <div className="text-red-400/70">No diagnostic details available.</div>
+      </div>
+    );
+  }
+
+  // Aggregate reasons
+  const counts: Record<string, number> = {};
+  for (const eventReasons of Object.values(reasons)) {
+    for (const r of eventReasons) {
+      counts[r] = (counts[r] || 0) + 1;
+    }
+  }
+
+  const REASON_LABELS: Record<string, string> = {
+    unmapped: 'Could not map to any pad position',
+    zone_conflict: 'Pad is outside all hand zones',
+    ownership_conflict: 'Pad ownership conflict (finger already assigned)',
+    speed_limit: 'Hand can\'t move fast enough',
+    no_valid_grip: 'No valid finger assignment exists',
+    beam_exhausted: 'Solver could not find a solution path',
+  };
+
+  return (
+    <div className="p-3 rounded-lg border border-red-500/30 bg-red-500/5 space-y-2">
+      <div className="text-[11px] font-medium text-red-300">
+        {plan.unplayableCount} event{plan.unplayableCount !== 1 ? 's' : ''} unplayable
+      </div>
+      <div className="space-y-1">
+        {Object.entries(counts)
+          .sort((a, b) => b[1] - a[1])
+          .map(([reason, count]) => (
+            <div key={reason} className="flex items-center gap-2 text-[10px]">
+              <span className="font-mono text-red-400 w-5 text-right">{count}</span>
+              <span className="text-red-300/80">{REASON_LABELS[reason] ?? reason}</span>
+            </div>
+          ))
+        }
+      </div>
+      <div className="text-[10px] text-gray-500 pt-1 border-t border-red-500/10">
+        Try adjusting pad positions on the grid, then re-generate.
+      </div>
+    </div>
   );
 }
 

--- a/product-reconciliation/v2/v2 repo/src/ui/hooks/useAutoAnalysis.ts
+++ b/product-reconciliation/v2/v2 repo/src/ui/hooks/useAutoAnalysis.ts
@@ -23,9 +23,40 @@ import { analyzeDifficulty, computeTradeoffProfile, classifyOptimizationDifficul
 import { generateCandidates } from '../../engine/optimization/multiCandidateGenerator';
 import { generateId } from '../../utils/idGenerator';
 import { type SolverConfig, type OptimizationMode } from '../../types/engineConfig';
-import { type Performance, type InstrumentConfig } from '../../types/performance';
+import { type Performance } from '../../types/performance';
 import { type FingerType } from '../../types/fingerModel';
 import { type Layout } from '../../types/layout';
+import { type Voice } from '../../types/voice';
+import { seedLayoutFromPose0 } from '../../engine/mapping/seedFromPose';
+import { createDefaultPose0, getPose0PadsWithOffset, fingerIdToHandAndFingerType } from '../../engine/prior/naturalHandPose';
+import { type FingerId, type NaturalHandPose } from '../../types/ergonomicPrior';
+
+/**
+ * Compute initial pad ownership from pose0 + layout.
+ * For pads in the layout that match a pose0 finger position,
+ * pre-assign the natural finger so the solver maintains consistent assignments.
+ */
+function computeInitialOwnership(
+  pose0: NaturalHandPose,
+  layout: Layout,
+): Record<string, { hand: 'left' | 'right'; finger: FingerType }> | undefined {
+  const posePads = getPose0PadsWithOffset(pose0, 0, true);
+  const padToFinger = new Map<string, string>();
+  for (const entry of posePads) {
+    padToFinger.set(`${entry.row},${entry.col}`, entry.fingerId);
+  }
+  const ownership: Record<string, { hand: 'left' | 'right'; finger: FingerType }> = {};
+  let count = 0;
+  for (const padKey of Object.keys(layout.padToVoice)) {
+    const fingerId = padToFinger.get(padKey);
+    if (fingerId) {
+      const { hand, finger } = fingerIdToHandAndFingerType(fingerId as FingerId);
+      ownership[padKey] = { hand, finger };
+      count++;
+    }
+  }
+  return count > 0 ? ownership : undefined;
+}
 
 /** User-facing mode selection: 'auto' delegates to classifyOptimizationDifficulty. */
 export type GenerationMode = OptimizationMode | 'auto';
@@ -112,43 +143,41 @@ function constraintsToManualAssignments(
 }
 
 /**
- * Builds a Layout by assigning each unmuted stream to its chromatic grid position.
+ * Builds a Layout using the natural hand pose to place sounds on adjacent pads.
  *
- * Uses the same formula as the solver's internal noteToGrid fallback:
- *   offset = noteNumber - bottomLeftNote
- *   row    = floor(offset / cols)
- *   col    = offset % cols
+ * Most-played sounds get the most dominant finger positions (index, middle, ring).
+ * Overflow sounds fill adjacent remaining pads. This keeps all voices within
+ * reachable hand zones and avoids the zone conflicts that chromatic mapping causes.
  *
- * Called by generateFull() when the active layout has no pad assignments yet,
- * so that "Generate from scratch" immediately shows pad positions on the grid.
+ * Preserves voice identity: Voice.id = stream.id so the voiceId lookup chain works.
  */
 function buildAutoLayout(
   soundStreams: SoundStream[],
-  instrumentConfig: InstrumentConfig,
+  performance: Performance,
   existingLayout: Layout,
 ): Layout {
-  const padToVoice: Layout['padToVoice'] = {};
+  const activeStreams = soundStreams.filter(s => !s.muted);
+  if (activeStreams.length === 0) return existingLayout;
 
-  for (const stream of soundStreams.filter(s => !s.muted)) {
-    const offset = stream.originalMidiNote - instrumentConfig.bottomLeftNote;
-    if (offset < 0) continue;
-    const row = Math.floor(offset / instrumentConfig.cols);
-    const col = offset % instrumentConfig.cols;
-    if (row >= instrumentConfig.rows) continue;
-
-    padToVoice[`${row},${col}`] = {
+  // Build existingVoices map so seedLayoutFromPose0 preserves stream IDs
+  const existingVoices = new Map<number, Voice>();
+  for (const stream of activeStreams) {
+    existingVoices.set(stream.originalMidiNote, {
       id: stream.id,
       name: stream.name,
       sourceType: 'midi_track',
       sourceFile: '',
       originalMidiNote: stream.originalMidiNote,
       color: stream.color,
-    };
+    });
   }
+
+  const defaultPose = createDefaultPose0();
+  const seeded = seedLayoutFromPose0(performance, defaultPose, 0, existingVoices);
 
   return {
     ...existingLayout,
-    padToVoice,
+    padToVoice: seeded.padToVoice,
     layoutMode: 'auto',
     scoreCache: null,
   };
@@ -186,22 +215,24 @@ export function useAutoAnalysis() {
         dispatch({ type: 'SET_PROCESSING', payload: true });
 
         // If the layout has no pad assignments, auto-build from streams
-        // so that importing MIDI immediately produces analysis results.
+        // using the natural hand pose to place sounds on adjacent pads.
         let effectiveLayout = layout;
         if (Object.keys(layout.padToVoice).length === 0) {
-          effectiveLayout = buildAutoLayout(activeStreams, state.instrumentConfig, layout);
+          effectiveLayout = buildAutoLayout(activeStreams, performance, layout);
           if (Object.keys(effectiveLayout.padToVoice).length === 0) {
-            // Still empty after auto-build (all notes out of range) — bail
+            // Still empty after auto-build — bail
             dispatch({ type: 'SET_PROCESSING', payload: false });
             return;
           }
           dispatch({ type: 'BULK_ASSIGN_PADS', payload: effectiveLayout.padToVoice });
         }
 
+        const defaultPose = createDefaultPose0();
         const solverConfig: SolverConfig = {
           instrumentConfig: state.instrumentConfig,
           layout: effectiveLayout,
           sourceLayoutRole: effectiveLayout.role,
+          initialPadOwnership: computeInitialOwnership(defaultPose, effectiveLayout),
         };
         const solver = createBeamSolver(solverConfig);
 
@@ -257,13 +288,12 @@ export function useAutoAnalysis() {
     try {
       const performance = getActivePerformance(state);
 
-      // If the layout has no pad assignments yet, auto-assign each unmuted stream
-      // to its chromatic grid position (the same formula the solver uses internally
-      // as a fallback). Dispatch BULK_ASSIGN_PADS so the grid immediately shows the
-      // assignments — keeping generation tightly coupled to what's on screen.
+      // If the layout has no pad assignments yet, seed from the natural hand pose.
+      // Most-played sounds → dominant finger positions (index, middle, ring).
+      // Dispatch BULK_ASSIGN_PADS so the grid immediately shows the assignments.
       let effectiveLayout = layout;
       if (Object.keys(layout.padToVoice).length === 0) {
-        effectiveLayout = buildAutoLayout(state.soundStreams, state.instrumentConfig, layout);
+        effectiveLayout = buildAutoLayout(state.soundStreams, performance, layout);
         dispatch({ type: 'BULK_ASSIGN_PADS', payload: effectiveLayout.padToVoice });
       }
 
@@ -279,7 +309,8 @@ export function useAutoAnalysis() {
       const modeLabel = resolvedMode === 'deep' ? 'Thorough' : 'Quick';
       setGenerationProgress(`${modeLabel} optimization: generating 3 candidates...`);
 
-      const generationResult = await generateCandidates(performance, null, {
+      const defaultPose = createDefaultPose0();
+      const generationResult = await generateCandidates(performance, defaultPose, {
         count: 3,
         optimizationMode: resolvedMode,
         engineConfig: state.engineConfig,

--- a/product-reconciliation/v2/v2 repo/src/ui/pages/ProjectLibraryPage.tsx
+++ b/product-reconciliation/v2/v2 repo/src/ui/pages/ProjectLibraryPage.tsx
@@ -2,163 +2,18 @@
  * ProjectLibraryPage.
  *
  * Browse, create, open, and manage projects.
- * MIDI import creates a new project with sound naming step.
+ * MIDI import happens inside the editor workspace via useLaneImport.
  */
 
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { type ProjectState, type SoundStream, type SoundEvent, createEmptyProjectState } from '../state/projectState';
-import { listProjects, saveProject, deleteProject, removeFromIndex, clearProjectIndex, type ProjectLibraryEntry } from '../persistence/projectStorage';
-import { parseMidiFileToProject } from '../../import/midiImport';
-import { analyzePerformance } from '../../engine/structure/performanceAnalyzer';
+import { type ProjectState, createEmptyProjectState } from '../state/projectState';
+import { listProjects, saveProject, removeFromIndex, clearProjectIndex, type ProjectLibraryEntry } from '../persistence/projectStorage';
 import { generateId } from '../../utils/idGenerator';
-
-/** Common drum kit presets for quick naming. */
-const DRUM_PRESETS: Record<number, string> = {
-  36: 'Kick', 37: 'Sidestick', 38: 'Snare', 39: 'Clap',
-  40: 'Snare 2', 41: 'Lo Tom', 42: 'Closed HH', 43: 'Lo Tom 2',
-  44: 'Pedal HH', 45: 'Mid Tom', 46: 'Open HH', 47: 'Mid Tom 2',
-  48: 'Hi Tom', 49: 'Crash', 50: 'Hi Tom 2', 51: 'Ride',
-  52: 'China', 53: 'Ride Bell', 54: 'Tambourine', 55: 'Splash',
-  56: 'Cowbell', 57: 'Crash 2',
-};
-
-const VOICE_COLORS = [
-  '#ef4444', '#3b82f6', '#22c55e', '#f59e0b', '#a855f7', '#06b6d4',
-  '#ec4899', '#f97316', '#84cc16', '#14b8a6', '#6366f1', '#d946ef',
-];
-
-type Step = 'library' | 'naming';
-
-interface PendingImport {
-  name: string;
-  streams: SoundStream[];
-  tempo: number;
-  instrumentConfig: ProjectState['instrumentConfig'];
-  sections: ProjectState['sections'];
-  voiceProfiles: ProjectState['voiceProfiles'];
-}
 
 export function ProjectLibraryPage() {
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>('library');
   const [savedProjects, setSavedProjects] = useState<ProjectLibraryEntry[]>(() => listProjects());
-  const [pendingImport, setPendingImport] = useState<PendingImport | null>(null);
-  const [dragOver, setDragOver] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  // ---- MIDI Import ----
-
-  const handleFile = useCallback(async (file: File) => {
-    try {
-      setError(null);
-      const projectData = await parseMidiFileToProject(file);
-      const structure = analyzePerformance(
-        projectData.performance.events,
-        projectData.performance.tempo ?? 120,
-      );
-
-      // Decompose performance into sound streams
-      const byNote = new Map<number, import('../../types/performanceEvent').PerformanceEvent[]>();
-      for (const e of projectData.performance.events) {
-        const list = byNote.get(e.noteNumber) ?? [];
-        list.push(e);
-        byNote.set(e.noteNumber, list);
-      }
-
-      const sortedNotes = [...byNote.keys()].sort((a, b) => a - b);
-      const streams: SoundStream[] = sortedNotes.map((noteNumber, i) => {
-        const events: SoundEvent[] = (byNote.get(noteNumber) ?? []).map(e => ({
-          startTime: e.startTime,
-          duration: e.duration ?? 0.25,
-          velocity: e.velocity ?? 100,
-          eventKey: e.eventKey ?? `${noteNumber}:${e.startTime}`,
-        }));
-
-        const preset = DRUM_PRESETS[noteNumber];
-        return {
-          id: generateId('stream'),
-          name: preset ?? `Note ${noteNumber}`,
-          color: VOICE_COLORS[i % VOICE_COLORS.length],
-          originalMidiNote: noteNumber,
-          events,
-          muted: false,
-        };
-      });
-
-      setPendingImport({
-        name: projectData.performance.name ?? 'Untitled',
-        streams,
-        tempo: projectData.performance.tempo ?? 120,
-        instrumentConfig: projectData.instrumentConfig,
-        sections: structure.sections,
-        voiceProfiles: structure.voiceProfiles,
-      });
-      setStep('naming');
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to parse MIDI file');
-    }
-  }, []);
-
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    setDragOver(false);
-    const file = e.dataTransfer.files[0];
-    if (file) handleFile(file);
-  }, [handleFile]);
-
-  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) handleFile(file);
-  }, [handleFile]);
-
-  // ---- Sound Naming Step ----
-
-  const handleCreateProject = useCallback(() => {
-    if (!pendingImport) return;
-
-    const now = new Date().toISOString();
-    const id = generateId('proj');
-
-    const state: ProjectState = {
-      ...createEmptyProjectState(),
-      id,
-      name: pendingImport.name,
-      createdAt: now,
-      updatedAt: now,
-      soundStreams: pendingImport.streams,
-      tempo: pendingImport.tempo,
-      instrumentConfig: pendingImport.instrumentConfig,
-      sections: pendingImport.sections,
-      voiceProfiles: pendingImport.voiceProfiles,
-    };
-
-    saveProject(state);
-    setSavedProjects(listProjects());
-    setPendingImport(null);
-    setStep('library');
-    navigate(`/project/${id}`);
-  }, [pendingImport, navigate]);
-
-  const applyDrumPresets = useCallback(() => {
-    if (!pendingImport) return;
-    setPendingImport({
-      ...pendingImport,
-      streams: pendingImport.streams.map(s => ({
-        ...s,
-        name: DRUM_PRESETS[s.originalMidiNote] ?? s.name,
-      })),
-    });
-  }, [pendingImport]);
-
-  const updateStreamName = useCallback((streamId: string, name: string) => {
-    if (!pendingImport) return;
-    setPendingImport({
-      ...pendingImport,
-      streams: pendingImport.streams.map(s =>
-        s.id === streamId ? { ...s, name } : s
-      ),
-    });
-  }, [pendingImport]);
 
   // ---- New Blank Project ----
 
@@ -185,12 +40,6 @@ export function ProjectLibraryPage() {
     navigate(`/project/${id}`);
   }, [navigate]);
 
-  // @ts-expect-error Declared for future use, not yet wired to UI
-  const handleDeleteProject = useCallback((id: string) => {
-    deleteProject(id);
-    setSavedProjects(listProjects());
-  }, []);
-
   const handleRemoveFromHistory = useCallback((id: string) => {
     removeFromIndex(id);
     setSavedProjects(listProjects());
@@ -203,111 +52,11 @@ export function ProjectLibraryPage() {
 
   // ---- Render ----
 
-  if (step === 'naming' && pendingImport) {
-    return (
-      <div className="max-w-2xl mx-auto space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold mb-1">Name Your Sounds</h1>
-          <p className="text-gray-400 text-sm">
-            Each unique MIDI note becomes an independent sound stream.
-            Give each one a meaningful name.
-          </p>
-        </div>
-
-        {/* Project name */}
-        <div>
-          <label className="text-xs text-gray-500 block mb-1">Project Name</label>
-          <input
-            className="w-full bg-gray-900 border border-gray-700 rounded px-3 py-2 text-gray-200 focus:border-blue-500 focus:outline-none"
-            value={pendingImport.name}
-            onChange={e => setPendingImport({ ...pendingImport, name: e.target.value })}
-          />
-        </div>
-
-        {/* Sound streams */}
-        <div className="p-4 rounded-lg bg-gray-800/50 border border-gray-700 space-y-3">
-          <div className="flex items-center justify-between">
-            <span className="text-sm font-medium text-gray-200">
-              {pendingImport.streams.length} sounds detected
-            </span>
-            <button
-              className="text-[11px] px-2 py-1 rounded bg-gray-700 hover:bg-gray-600 text-gray-300"
-              onClick={applyDrumPresets}
-            >
-              Apply GM Drum Names
-            </button>
-          </div>
-          <div className="space-y-2">
-            {pendingImport.streams.map(s => (
-              <div key={s.id} className="flex items-center gap-2">
-                <span
-                  className="w-3 h-3 rounded-sm flex-shrink-0"
-                  style={{ backgroundColor: s.color }}
-                />
-                <span className="text-[11px] text-gray-500 w-10 flex-shrink-0 font-mono">
-                  #{s.originalMidiNote}
-                </span>
-                <input
-                  className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 focus:border-blue-500 focus:outline-none"
-                  value={s.name}
-                  onChange={e => updateStreamName(s.id, e.target.value)}
-                  placeholder="Sound name..."
-                />
-                <span className="text-[10px] text-gray-500 flex-shrink-0 w-14 text-right">
-                  {s.events.length} hits
-                </span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex gap-3">
-          <button
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-sm"
-            onClick={() => { setStep('library'); setPendingImport(null); }}
-          >
-            Cancel
-          </button>
-          <button
-            className="flex-1 py-2 bg-blue-600 hover:bg-blue-500 rounded text-sm font-medium text-white"
-            onClick={handleCreateProject}
-          >
-            Create Project
-          </button>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <div>
         <h1 className="text-2xl font-bold mb-1">PushFlow</h1>
         <p className="text-gray-400 text-sm">Performance Ergonomics Optimizer for Ableton Push 3</p>
-      </div>
-
-      {/* MIDI upload zone */}
-      <div
-        className={`border-2 border-dashed rounded-xl p-6 text-center transition-colors cursor-pointer ${
-          dragOver ? 'border-blue-500 bg-blue-500/10' : 'border-gray-700 hover:border-gray-600'
-        }`}
-        onDragOver={e => { e.preventDefault(); setDragOver(true); }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={handleDrop}
-        onClick={() => document.getElementById('midi-input')?.click()}
-      >
-        <input
-          id="midi-input"
-          type="file"
-          accept=".mid,.midi"
-          className="hidden"
-          onChange={handleInputChange}
-        />
-        <div className="text-gray-400">
-          <div className="text-lg mb-1">Import MIDI File</div>
-          <div className="text-sm text-gray-500">Drop a .mid file or click to browse</div>
-        </div>
       </div>
 
       {/* Quick actions */}
@@ -331,12 +80,6 @@ export function ProjectLibraryPage() {
           Temporal Evaluator
         </button>
       </div>
-
-      {error && (
-        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
-          {error}
-        </div>
-      )}
 
       {/* Saved Projects */}
       {savedProjects.length > 0 && (

--- a/product-reconciliation/v2/v2 repo/test/engine/optimization/midiDiagnostic.test.ts
+++ b/product-reconciliation/v2/v2 repo/test/engine/optimization/midiDiagnostic.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Diagnostic test: Trace exactly why TEST MIDI 1 events are unplayable.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Midi } from '@tonejs/midi';
+import { type Performance } from '../../../src/types/performance';
+import { type PerformanceEvent } from '../../../src/types/performanceEvent';
+import { type Voice } from '../../../src/types/voice';
+import { type Layout } from '../../../src/types/layout';
+import { type SolverConfig } from '../../../src/types/engineConfig';
+import { seedLayoutFromPose0 } from '../../../src/engine/mapping/seedFromPose';
+import { createDefaultPose0 } from '../../../src/engine/prior/naturalHandPose';
+import { createBeamSolver } from '../../../src/engine/solvers/beamSolver';
+import { buildNoteToPadIndex, buildVoiceIdToPadIndex, resolveEventToPad } from '../../../src/engine/mapping/mappingResolver';
+import { isZoneValid, allPadsInZone } from '../../../src/engine/surface/handZone';
+import {
+  DEFAULT_TEST_INSTRUMENT_CONFIG,
+  DEFAULT_ENGINE_CONFIG,
+  countHandUsage,
+} from '../../helpers/testHelpers';
+
+function loadTestMidi() {
+  const midiPath = path.resolve(__dirname, '../../../../../../TEST MIDI 1.mid');
+  const buffer = fs.readFileSync(midiPath);
+  const midiData = new Midi(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+
+  const events: PerformanceEvent[] = [];
+  midiData.tracks.forEach((track) => {
+    const timeTally = new Map<string, number>();
+    track.notes.forEach((note) => {
+      const noteNumber = note.midi;
+      const channelLabel = track.channel + 1;
+      const nominalTime = note.ticks !== undefined ? note.ticks : Math.round(note.time * 10000);
+      const hashKey = `${nominalTime}:${noteNumber}:${channelLabel}`;
+      const ordinal = (timeTally.get(hashKey) || 0) + 1;
+      timeTally.set(hashKey, ordinal);
+      events.push({
+        noteNumber, startTime: note.time, duration: note.duration,
+        velocity: Math.round(note.velocity * 127), channel: channelLabel,
+        eventKey: `${hashKey}:${ordinal}`,
+      });
+    });
+  });
+  events.sort((a, b) => a.startTime - b.startTime);
+
+  const uniqueNotes = [...new Set(events.map(e => e.noteNumber))].sort((a, b) => a - b);
+  return { events, uniqueNotes, tempo: midiData.header.tempos.length > 0 ? Math.round(midiData.header.tempos[0].bpm) : 120 };
+}
+
+describe('MIDI diagnostic', () => {
+  let midi: ReturnType<typeof loadTestMidi>;
+  let layout: Layout;
+  let performance: Performance;
+
+  beforeAll(() => {
+    midi = loadTestMidi();
+    performance = { events: midi.events, tempo: midi.tempo, name: 'TEST MIDI 1' };
+
+    const existingVoices = new Map<number, Voice>();
+    midi.uniqueNotes.forEach((n, i) => {
+      existingVoices.set(n, {
+        id: `stream-${n}`, name: `Note ${n}`, sourceType: 'midi_track',
+        sourceFile: '', originalMidiNote: n, color: '#444',
+      });
+    });
+
+    const pose0 = createDefaultPose0();
+    layout = seedLayoutFromPose0(performance, pose0, 0, existingVoices);
+  });
+
+  it('diagnose event grouping and zone validity', () => {
+    // Build mapping indices
+    const noteIndex = buildNoteToPadIndex(layout.padToVoice);
+    const voiceIdIndex = buildVoiceIdToPadIndex(layout.padToVoice);
+
+    // Group events by timestamp
+    const EPSILON = 0.001;
+    const groups: Array<{ time: number; events: PerformanceEvent[]; pads: Array<{ row: number; col: number }> }> = [];
+
+    for (const event of midi.events) {
+      const resolution = resolveEventToPad(event, voiceIdIndex, noteIndex, DEFAULT_TEST_INSTRUMENT_CONFIG, 'strict');
+      const pad = resolution.source === 'mapping' ? resolution.pad : null;
+
+      const existing = groups.find(g => Math.abs(g.time - event.startTime) < EPSILON);
+      if (existing) {
+        existing.events.push(event);
+        if (pad) existing.pads.push(pad);
+      } else {
+        groups.push({ time: event.startTime, events: [event], pads: pad ? [pad] : [] });
+      }
+    }
+
+    groups.sort((a, b) => a.time - b.time);
+
+    console.log('\n  === Event Groups ===');
+    for (const g of groups) {
+      const noteNames = g.events.map(e => `note${e.noteNumber}`).join('+');
+      const padPositions = g.pads.map(p => `(${p.row},${p.col})`).join('+');
+
+      // Check zone validity for each hand
+      const leftValid = g.pads.length > 0 && allPadsInZone(g.pads, 'left');
+      const rightValid = g.pads.length > 0 && allPadsInZone(g.pads, 'right');
+      const needsSplit = g.pads.length > 0 && !leftValid && !rightValid;
+
+      console.log(`  t=${g.time.toFixed(3)} | ${noteNames.padEnd(30)} | pads=${padPositions.padEnd(30)} | L=${leftValid ? 'ok' : 'no'} R=${rightValid ? 'ok' : 'no'}${needsSplit ? ' SPLIT' : ''}`);
+    }
+
+    // Count how many groups need split-chord handling
+    const splitGroups = groups.filter(g => {
+      const leftValid = g.pads.length > 0 && allPadsInZone(g.pads, 'left');
+      const rightValid = g.pads.length > 0 && allPadsInZone(g.pads, 'right');
+      return g.pads.length > 0 && !leftValid && !rightValid;
+    });
+
+    console.log(`\n  ${groups.length} total groups, ${splitGroups.length} need split-chord`);
+    console.log(`  Max simultaneous pads: ${Math.max(...groups.map(g => g.pads.length))}`);
+
+    // Check which pads are in which zones
+    console.log('\n  === Pad Zone Analysis ===');
+    for (const [key, voice] of Object.entries(layout.padToVoice)) {
+      const [row, col] = key.split(',').map(Number);
+      const leftOk = isZoneValid({ row, col }, 'left');
+      const rightOk = isZoneValid({ row, col }, 'right');
+      console.log(`  Pad (${row},${col}) → ${voice.name} | L=${leftOk ? 'ok' : 'no'} R=${rightOk ? 'ok' : 'no'}`);
+    }
+  });
+
+  it('diagnose solver step-by-step', async () => {
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+    };
+    const solver = createBeamSolver(solverConfig);
+    const result = await solver.solve(performance, { ...DEFAULT_ENGINE_CONFIG, beamWidth: 15 });
+
+    // Analyze which events are unplayable
+    console.log('\n  === Unplayable Events ===');
+    for (const fa of result.fingerAssignments) {
+      if (fa.assignedHand === 'Unplayable') {
+        console.log(`  Event #${fa.eventIndex} note=${fa.noteNumber} t=${fa.startTime.toFixed(3)} key=${fa.eventKey}`);
+      }
+    }
+
+    // Analyze playable events to see ownership pattern
+    console.log('\n  === Playable Events (with finger assignments) ===');
+    for (const fa of result.fingerAssignments) {
+      if (fa.assignedHand !== 'Unplayable') {
+        console.log(`  Event #${fa.eventIndex} note=${fa.noteNumber} t=${fa.startTime.toFixed(3)} → ${fa.assignedHand} ${fa.finger} at (${fa.row},${fa.col})`);
+      }
+    }
+
+    const usage = countHandUsage(result);
+    console.log(`\n  Summary: ${usage.left}L + ${usage.right}R + ${usage.unplayable}U = ${usage.left + usage.right + usage.unplayable} total`);
+
+    // Just report, don't assert (this is diagnostic)
+    expect(true).toBe(true);
+  });
+});

--- a/product-reconciliation/v2/v2 repo/test/engine/optimization/pose0DrumLayout.test.ts
+++ b/product-reconciliation/v2/v2 repo/test/engine/optimization/pose0DrumLayout.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Integration test: Pose0-seeded drum layout produces playable solutions.
+ *
+ * Validates that the natural hand pose layout strategy places drum sounds
+ * on adjacent pads within reachable hand zones, and that the solver can
+ * find valid finger assignments for typical drum patterns.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { type Voice } from '../../../src/types/voice';
+import { type Layout } from '../../../src/types/layout';
+import { type Performance } from '../../../src/types/performance';
+import { type PerformanceEvent } from '../../../src/types/performanceEvent';
+import { type SolverConfig } from '../../../src/types/engineConfig';
+import { seedLayoutFromPose0 } from '../../../src/engine/mapping/seedFromPose';
+import { createDefaultPose0 } from '../../../src/engine/prior/naturalHandPose';
+import { createBeamSolver } from '../../../src/engine/solvers/beamSolver';
+import { generateCandidates } from '../../../src/engine/optimization/multiCandidateGenerator';
+import {
+  createTestPerformance,
+  createSimultaneousPerformance,
+  generateEventKey,
+  DEFAULT_TEST_INSTRUMENT_CONFIG,
+  DEFAULT_ENGINE_CONFIG,
+  countHandUsage,
+  assertNoNaNs,
+  assertValidGridPositions,
+  assertMappingIntegrity,
+} from '../../helpers/testHelpers';
+
+// ============================================================================
+// Voice factory preserving stream IDs (simulates the real voiceId chain)
+// ============================================================================
+
+function buildExistingVoices(
+  specs: Array<{ id: string; name: string; midi: number; color: string }>
+): Map<number, Voice> {
+  const map = new Map<number, Voice>();
+  for (const s of specs) {
+    map.set(s.midi, {
+      id: s.id,
+      name: s.name,
+      sourceType: 'midi_track',
+      sourceFile: '',
+      originalMidiNote: s.midi,
+      color: s.color,
+    });
+  }
+  return map;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Pose0-seeded drum layout', () => {
+  const drumVoices = buildExistingVoices([
+    { id: 'stream-kick', name: 'Kick', midi: 36, color: '#ef4444' },
+    { id: 'stream-snare', name: 'Snare', midi: 38, color: '#3b82f6' },
+    { id: 'stream-hihat', name: 'Hi-Hat', midi: 42, color: '#22c55e' },
+  ]);
+
+  it('places all voices within reachable zones (cols 0-7)', () => {
+    const perf = createTestPerformance([
+      { noteNumber: 36, startTime: 0.0 },
+      { noteNumber: 38, startTime: 0.5 },
+      { noteNumber: 42, startTime: 1.0 },
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    // All voices should be placed
+    const voices = Object.values(layout.padToVoice);
+    expect(voices.length).toBe(3);
+
+    // All pads should be within 8x8 grid
+    for (const [key] of Object.entries(layout.padToVoice)) {
+      const [row, col] = key.split(',').map(Number);
+      expect(row).toBeGreaterThanOrEqual(0);
+      expect(row).toBeLessThan(8);
+      expect(col).toBeGreaterThanOrEqual(0);
+      expect(col).toBeLessThan(8);
+    }
+  });
+
+  it('preserves voice IDs from existingVoices', () => {
+    const perf = createTestPerformance([
+      { noteNumber: 36, startTime: 0.0 },
+      { noteNumber: 38, startTime: 0.5 },
+      { noteNumber: 42, startTime: 1.0 },
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    const voiceIds = Object.values(layout.padToVoice).map(v => v.id);
+    expect(voiceIds).toContain('stream-kick');
+    expect(voiceIds).toContain('stream-snare');
+    expect(voiceIds).toContain('stream-hihat');
+  });
+
+  it('generates playable candidates for a simple drum pattern', async () => {
+    // Typical drum groove: kick+hihat together, snare alone, hihat alone
+    const perf = createTestPerformance([
+      { noteNumber: 36, startTime: 0.0 },   // kick
+      { noteNumber: 42, startTime: 0.0 },   // hihat (simultaneous)
+      { noteNumber: 42, startTime: 0.25 },  // hihat
+      { noteNumber: 38, startTime: 0.5 },   // snare
+      { noteNumber: 42, startTime: 0.5 },   // hihat (simultaneous)
+      { noteNumber: 42, startTime: 0.75 },  // hihat
+      { noteNumber: 36, startTime: 1.0 },   // kick
+      { noteNumber: 42, startTime: 1.0 },   // hihat (simultaneous)
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    const result = await generateCandidates(perf, pose0, {
+      count: 3,
+      engineConfig: DEFAULT_ENGINE_CONFIG,
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      baseLayout: layout,
+      activeLayout: layout,
+    });
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+
+    // At least one candidate should have mostly playable events
+    const bestCandidate = result.candidates[0];
+    const usage = countHandUsage(bestCandidate.executionPlan);
+    const totalEvents = 8;
+    const playableRatio = (usage.left + usage.right) / totalEvents;
+
+    // Must have >50% playable events (should be close to 100%)
+    expect(playableRatio).toBeGreaterThan(0.5);
+  });
+
+  it('handles simultaneous kick+hihat without zone conflicts', async () => {
+    const perf = createSimultaneousPerformance([
+      { time: 0.0, notes: [36, 42] },  // kick + hihat
+      { time: 0.5, notes: [38, 42] },  // snare + hihat
+      { time: 1.0, notes: [36, 42] },  // kick + hihat
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    const result = await generateCandidates(perf, pose0, {
+      count: 1,
+      engineConfig: DEFAULT_ENGINE_CONFIG,
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      baseLayout: layout,
+    });
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+
+    const usage = countHandUsage(result.candidates[0].executionPlan);
+    // At least some events should be playable
+    expect(usage.left + usage.right).toBeGreaterThan(0);
+    // Unplayable should be minority
+    expect(usage.unplayable).toBeLessThan(4);
+  });
+
+  it('places most-played sounds on dominant finger positions', () => {
+    // Hi-hat is most frequent → should get index finger position
+    const perf = createTestPerformance([
+      { noteNumber: 42, startTime: 0.0 },
+      { noteNumber: 42, startTime: 0.25 },
+      { noteNumber: 42, startTime: 0.5 },
+      { noteNumber: 42, startTime: 0.75 },
+      { noteNumber: 36, startTime: 0.0 },
+      { noteNumber: 36, startTime: 0.5 },
+      { noteNumber: 38, startTime: 0.25 },
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    // Default pose0: L_INDEX at (3,3), R_INDEX at (3,4)
+    // Hi-hat (most played) should be at one of the index finger positions
+    let hihatPad: string | null = null;
+    for (const [key, voice] of Object.entries(layout.padToVoice)) {
+      if (voice.id === 'stream-hihat') {
+        hihatPad = key;
+        break;
+      }
+    }
+
+    expect(hihatPad).not.toBeNull();
+    // Should be at L_INDEX (3,3) or R_INDEX (3,4) — the first two priority positions
+    expect(['3,3', '3,4']).toContain(hihatPad);
+  });
+});
+
+// ============================================================================
+// Strict-mode solver tests (matches real auto-analysis path)
+// ============================================================================
+
+describe('Pose0-seeded layout with strict-mode solver', () => {
+  const drumVoices = buildExistingVoices([
+    { id: 'stream-kick', name: 'Kick', midi: 36, color: '#ef4444' },
+    { id: 'stream-snare', name: 'Snare', midi: 38, color: '#3b82f6' },
+    { id: 'stream-hihat', name: 'Hi-Hat', midi: 42, color: '#22c55e' },
+  ]);
+
+  /**
+   * Creates a performance with voiceId on events, matching the real app flow
+   * where getActivePerformance sets voiceId = stream.id.
+   */
+  function createDrumPerformanceWithVoiceIds(
+    notes: Array<{ noteNumber: number; startTime: number; voiceId: string }>
+  ): Performance {
+    const events: PerformanceEvent[] = notes.map((n) => ({
+      noteNumber: n.noteNumber,
+      startTime: n.startTime,
+      duration: 0.25,
+      velocity: 100,
+      channel: 1,
+      eventKey: generateEventKey(n.noteNumber, n.startTime),
+      voiceId: n.voiceId,
+    }));
+    return { events, tempo: 120, name: 'Drum Pattern' };
+  }
+
+  it('solver in strict mode resolves all events (no unmapped) with pose0 layout', async () => {
+    const perf = createDrumPerformanceWithVoiceIds([
+      { noteNumber: 36, startTime: 0.0, voiceId: 'stream-kick' },
+      { noteNumber: 42, startTime: 0.0, voiceId: 'stream-hihat' },
+      { noteNumber: 42, startTime: 0.25, voiceId: 'stream-hihat' },
+      { noteNumber: 38, startTime: 0.5, voiceId: 'stream-snare' },
+      { noteNumber: 42, startTime: 0.5, voiceId: 'stream-hihat' },
+      { noteNumber: 42, startTime: 0.75, voiceId: 'stream-hihat' },
+      { noteNumber: 36, startTime: 1.0, voiceId: 'stream-kick' },
+      { noteNumber: 42, startTime: 1.0, voiceId: 'stream-hihat' },
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    // Strict mode — exactly like auto-analysis path
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+    };
+    const solver = createBeamSolver(solverConfig);
+    const result = await solver.solve(perf, { ...DEFAULT_ENGINE_CONFIG, beamWidth: 15 });
+
+    // All 8 events must be in the result
+    expect(result.fingerAssignments.length).toBe(8);
+
+    // Zero unplayable events — this is the critical assertion
+    const usage = countHandUsage(result);
+    expect(usage.unplayable).toBe(0);
+    expect(usage.left + usage.right).toBe(8);
+
+    assertNoNaNs(result);
+    assertValidGridPositions(result);
+    assertMappingIntegrity(result);
+  });
+
+  it('solver in strict mode handles 4-bar drum loop with zero unplayable', async () => {
+    // Realistic 4-bar loop: kick on 1 and 3, snare on 2 and 4, hi-hat on every 8th
+    const notes: Array<{ noteNumber: number; startTime: number; voiceId: string }> = [];
+    const bpm = 120;
+    const beatDuration = 60 / bpm; // 0.5s per beat
+
+    for (let bar = 0; bar < 4; bar++) {
+      const barStart = bar * 4 * beatDuration;
+      for (let beat = 0; beat < 4; beat++) {
+        const t = barStart + beat * beatDuration;
+        // Hi-hat on every beat
+        notes.push({ noteNumber: 42, startTime: t, voiceId: 'stream-hihat' });
+        // Hi-hat on upbeat
+        notes.push({ noteNumber: 42, startTime: t + beatDuration / 2, voiceId: 'stream-hihat' });
+        // Kick on beats 1, 3
+        if (beat === 0 || beat === 2) {
+          notes.push({ noteNumber: 36, startTime: t, voiceId: 'stream-kick' });
+        }
+        // Snare on beats 2, 4
+        if (beat === 1 || beat === 3) {
+          notes.push({ noteNumber: 38, startTime: t, voiceId: 'stream-snare' });
+        }
+      }
+    }
+
+    const perf = createDrumPerformanceWithVoiceIds(notes);
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+    };
+    const solver = createBeamSolver(solverConfig);
+    const result = await solver.solve(perf, { ...DEFAULT_ENGINE_CONFIG, beamWidth: 15 });
+
+    expect(result.fingerAssignments.length).toBe(notes.length);
+
+    const usage = countHandUsage(result);
+    // All events must be playable for this simple pattern
+    expect(usage.unplayable).toBe(0);
+    expect(usage.left + usage.right).toBe(notes.length);
+  });
+
+  it('noteNumber fallback works in strict mode (no voiceId on events)', async () => {
+    // Tests the path where events don't have voiceId — relies on noteNumber lookup
+    const perf = createTestPerformance([
+      { noteNumber: 36, startTime: 0.0 },
+      { noteNumber: 38, startTime: 0.5 },
+      { noteNumber: 42, startTime: 0.0 },
+      { noteNumber: 42, startTime: 0.5 },
+    ]);
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(perf, pose0, 0, drumVoices);
+
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+    };
+    const solver = createBeamSolver(solverConfig);
+    const result = await solver.solve(perf, DEFAULT_ENGINE_CONFIG);
+
+    expect(result.fingerAssignments.length).toBe(4);
+    expect(result.unplayableCount).toBe(0);
+  });
+});

--- a/product-reconciliation/v2/v2 repo/test/engine/optimization/testMidi1Integration.test.ts
+++ b/product-reconciliation/v2/v2 repo/test/engine/optimization/testMidi1Integration.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Integration test: TEST MIDI 1.mid end-to-end through the engine pipeline.
+ *
+ * Simulates the exact user flow:
+ * 1. Parse the MIDI file (like useLaneImport does)
+ * 2. Build sound streams from lanes (like SYNC_STREAMS_FROM_LANES does)
+ * 3. Build auto-layout from natural hand pose (like useAutoAnalysis does)
+ * 4. Run the beam solver and generate candidates
+ * 5. Assert that candidates have playable events (not all unplayable)
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { Midi } from '@tonejs/midi';
+import { type Performance } from '../../../src/types/performance';
+import { type PerformanceEvent } from '../../../src/types/performanceEvent';
+import { type Voice } from '../../../src/types/voice';
+import { seedLayoutFromPose0 } from '../../../src/engine/mapping/seedFromPose';
+import { createDefaultPose0, getPose0PadsWithOffset, fingerIdToHandAndFingerType } from '../../../src/engine/prior/naturalHandPose';
+import { generateCandidates } from '../../../src/engine/optimization/multiCandidateGenerator';
+import { createBeamSolver } from '../../../src/engine/solvers/beamSolver';
+import { type SolverConfig } from '../../../src/types/engineConfig';
+import {
+  DEFAULT_TEST_INSTRUMENT_CONFIG,
+  DEFAULT_ENGINE_CONFIG,
+  countHandUsage,
+} from '../../helpers/testHelpers';
+
+// ============================================================================
+// Load and parse TEST MIDI 1.mid
+// ============================================================================
+
+interface ParsedMidiData {
+  events: PerformanceEvent[];
+  tempo: number;
+  uniqueNotes: number[];
+}
+
+function loadTestMidi(): ParsedMidiData {
+  // Navigate from test/engine/optimization/ up to the workspace root (PushFlow V3)
+  const midiPath = path.resolve(__dirname, '../../../../../../TEST MIDI 1.mid');
+  const buffer = fs.readFileSync(midiPath);
+  const midiData = new Midi(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
+
+  const events: PerformanceEvent[] = [];
+  midiData.tracks.forEach((track) => {
+    const timeTally = new Map<string, number>();
+    track.notes.forEach((note) => {
+      const noteNumber = note.midi;
+      const channelLabel = track.channel + 1;
+      const nominalTime = note.ticks !== undefined ? note.ticks : Math.round(note.time * 10000);
+      const hashKey = `${nominalTime}:${noteNumber}:${channelLabel}`;
+      const ordinal = (timeTally.get(hashKey) || 0) + 1;
+      timeTally.set(hashKey, ordinal);
+      const eventKey = `${hashKey}:${ordinal}`;
+
+      events.push({
+        noteNumber,
+        startTime: note.time,
+        duration: note.duration,
+        velocity: Math.round(note.velocity * 127),
+        channel: channelLabel,
+        eventKey,
+      });
+    });
+  });
+
+  events.sort((a, b) => a.startTime - b.startTime);
+
+  const tempo = midiData.header.tempos.length > 0
+    ? Math.round(midiData.header.tempos[0].bpm)
+    : 120;
+
+  const uniqueNotes = [...new Set(events.map(e => e.noteNumber))].sort((a, b) => a - b);
+
+  return { events, tempo, uniqueNotes };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TEST MIDI 1.mid end-to-end', () => {
+  let midiData: ParsedMidiData;
+
+  beforeAll(() => {
+    midiData = loadTestMidi();
+  });
+
+  it('should parse the MIDI file successfully', () => {
+    expect(midiData.events.length).toBeGreaterThan(0);
+    expect(midiData.uniqueNotes.length).toBeGreaterThan(0);
+    console.log(`  Parsed: ${midiData.events.length} events, ${midiData.uniqueNotes.length} unique notes (${midiData.uniqueNotes.join(', ')}), tempo=${midiData.tempo} BPM`);
+  });
+
+  it('should seed a layout from natural hand pose with all voices placed', () => {
+    const performance: Performance = {
+      events: midiData.events,
+      tempo: midiData.tempo,
+      name: 'TEST MIDI 1',
+    };
+
+    // Build voices with stable IDs (simulating stream IDs)
+    const existingVoices = new Map<number, Voice>();
+    midiData.uniqueNotes.forEach((noteNumber, i) => {
+      existingVoices.set(noteNumber, {
+        id: `stream-${noteNumber}`,
+        name: `Note ${noteNumber}`,
+        sourceType: 'midi_track',
+        sourceFile: 'TEST MIDI 1.mid',
+        originalMidiNote: noteNumber,
+        color: `#${((i * 37 + 128) % 256).toString(16).padStart(2, '0')}4444`,
+      });
+    });
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(performance, pose0, 0, existingVoices);
+
+    const placedVoices = Object.values(layout.padToVoice);
+    expect(placedVoices.length).toBe(midiData.uniqueNotes.length);
+
+    // All voice IDs should match stream IDs
+    for (const voice of placedVoices) {
+      expect(voice.id).toMatch(/^stream-\d+$/);
+    }
+
+    // Log pad positions
+    console.log('  Pad positions:');
+    for (const [key, voice] of Object.entries(layout.padToVoice)) {
+      console.log(`    ${key} => ${voice.name} (id=${voice.id})`);
+    }
+  });
+
+  it('should produce playable candidates via generateCandidates', async () => {
+    const performance: Performance = {
+      events: midiData.events,
+      tempo: midiData.tempo,
+      name: 'TEST MIDI 1',
+    };
+
+    const existingVoices = new Map<number, Voice>();
+    midiData.uniqueNotes.forEach((noteNumber, i) => {
+      existingVoices.set(noteNumber, {
+        id: `stream-${noteNumber}`,
+        name: `Note ${noteNumber}`,
+        sourceType: 'midi_track',
+        sourceFile: 'TEST MIDI 1.mid',
+        originalMidiNote: noteNumber,
+        color: '#444444',
+      });
+    });
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(performance, pose0, 0, existingVoices);
+
+    const result = await generateCandidates(performance, pose0, {
+      count: 3,
+      engineConfig: DEFAULT_ENGINE_CONFIG,
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      baseLayout: layout,
+      activeLayout: layout,
+    });
+
+    expect(result.candidates.length).toBeGreaterThan(0);
+    console.log(`  Generated ${result.candidates.length} candidates`);
+
+    for (let i = 0; i < result.candidates.length; i++) {
+      const candidate = result.candidates[i];
+      const usage = countHandUsage(candidate.executionPlan);
+      const total = usage.left + usage.right + usage.unplayable;
+      const playableRatio = (usage.left + usage.right) / total;
+
+      console.log(`  Candidate #${i + 1} (${candidate.metadata.strategy}): L=${usage.left} R=${usage.right} Unplayable=${usage.unplayable} (${(playableRatio * 100).toFixed(0)}% playable)`);
+
+      // Log rejection reasons if any
+      if (candidate.executionPlan.rejectionReasons) {
+        const counts: Record<string, number> = {};
+        for (const reasons of Object.values(candidate.executionPlan.rejectionReasons)) {
+          for (const r of reasons) counts[r] = (counts[r] || 0) + 1;
+        }
+        console.log(`    Rejection reasons: ${JSON.stringify(counts)}`);
+      }
+
+      // THIS IS THE KEY ASSERTION: candidates must have playable events
+      expect(playableRatio).toBeGreaterThan(0.5);
+    }
+  });
+
+  it('should produce playable results via direct beam solver (allow-fallback)', async () => {
+    const performance: Performance = {
+      events: midiData.events,
+      tempo: midiData.tempo,
+      name: 'TEST MIDI 1',
+    };
+
+    const existingVoices = new Map<number, Voice>();
+    midiData.uniqueNotes.forEach((noteNumber) => {
+      existingVoices.set(noteNumber, {
+        id: `stream-${noteNumber}`,
+        name: `Note ${noteNumber}`,
+        sourceType: 'midi_track',
+        sourceFile: '',
+        originalMidiNote: noteNumber,
+        color: '#444',
+      });
+    });
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(performance, pose0, 0, existingVoices);
+
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+      mappingResolverMode: 'allow-fallback',
+    };
+    const solver = createBeamSolver(solverConfig);
+    const planResult = await solver.solve(performance, DEFAULT_ENGINE_CONFIG);
+
+    const usage = countHandUsage(planResult);
+    const total = usage.left + usage.right + usage.unplayable;
+    const playableRatio = total > 0 ? (usage.left + usage.right) / total : 0;
+
+    console.log(`  Direct solver (fallback): L=${usage.left} R=${usage.right} Unplayable=${usage.unplayable} Score=${planResult.score.toFixed(1)} (${(playableRatio * 100).toFixed(0)}% playable)`);
+
+    // Must have >50% playable events
+    expect(playableRatio).toBeGreaterThan(0.5);
+  });
+
+  it('should produce ZERO unplayable events via strict-mode solver', async () => {
+    // This matches the exact auto-analysis path in useAutoAnalysis.ts
+    const performance: Performance = {
+      events: midiData.events,
+      tempo: midiData.tempo,
+      name: 'TEST MIDI 1',
+    };
+
+    const existingVoices = new Map<number, Voice>();
+    midiData.uniqueNotes.forEach((noteNumber) => {
+      existingVoices.set(noteNumber, {
+        id: `stream-${noteNumber}`,
+        name: `Note ${noteNumber}`,
+        sourceType: 'midi_track',
+        sourceFile: '',
+        originalMidiNote: noteNumber,
+        color: '#444',
+      });
+    });
+
+    const pose0 = createDefaultPose0();
+    const layout = seedLayoutFromPose0(performance, pose0, 0, existingVoices);
+
+    // Strict mode with initial pad ownership — same as auto-analysis path.
+    // Compute ownership from pose0 finger positions.
+    const posePads = getPose0PadsWithOffset(pose0, 0, true);
+    const initialPadOwnership: Record<string, { hand: 'left' | 'right'; finger: import('../../../src/types/fingerModel').FingerType }> = {};
+    for (const entry of posePads) {
+      const padKey = `${entry.row},${entry.col}`;
+      if (layout.padToVoice[padKey]) {
+        const { hand, finger } = fingerIdToHandAndFingerType(entry.fingerId);
+        initialPadOwnership[padKey] = { hand, finger };
+      }
+    }
+
+    const solverConfig: SolverConfig = {
+      instrumentConfig: DEFAULT_TEST_INSTRUMENT_CONFIG,
+      layout,
+      initialPadOwnership,
+    };
+    const solver = createBeamSolver(solverConfig);
+    const planResult = await solver.solve(
+      performance,
+      { ...DEFAULT_ENGINE_CONFIG, beamWidth: 15 },
+    );
+
+    const usage = countHandUsage(planResult);
+    const total = usage.left + usage.right + usage.unplayable;
+    console.log(`  Direct solver (strict): L=${usage.left} R=${usage.right} Unplayable=${usage.unplayable} / ${total} total`);
+
+    // Zero unplayable — this is the exit criterion
+    expect(usage.unplayable).toBe(0);
+    expect(usage.left + usage.right).toBe(total);
+  });
+});


### PR DESCRIPTION
## Summary

- **Fixed "all events unplayable" bug** — `buildAutoLayout` used chromatic MIDI-note-to-grid mapping which scattered drum pads across the grid by MIDI pitch number, causing zone conflicts. Replaced with `seedLayoutFromPose0` which places most-played sounds on dominant finger positions in the natural hand pose.
- **Pre-seeded beam solver pad ownership** — new `initialPadOwnership` on `SolverConfig` prevents the solver from picking random grips on first encounter that lock sub-optimal finger assignments, causing cascading ownership failures.
- **Fixed default Pose0 thumb positions** — moved thumbs from row 0 to row 2 (adjacent to index finger) for biomechanical feasibility.
- **Removed "Import MIDI File" from home page** — only path is now "+ New Project" → import MIDI inside the editor workspace.
- **Added solver diagnostics** — `rejectionReasons` on `ExecutionPlanResult` explains WHY events are unplayable (unmapped, zone conflict, beam exhausted, etc.), shown in the analysis panel UI.

## Test Results

TEST MIDI 1.mid (48 events, 7 voices):
- **Before**: 0% playable (48/48 unplayable)
- **After**: 100% playable (48/48 assigned, 0 unplayable)
- All 3 generated candidates produce valid solutions

555 tests passing. Clean build.

## Test plan

- [x] TEST MIDI 1.mid produces 100% playable candidates via `generateCandidates`
- [x] Direct beam solver with initial pad ownership produces 0 unplayable events
- [x] Pose0-seeded layout places voices on adjacent finger positions
- [x] Voice identity chain preserved (Voice.id = stream.id)
- [x] Home page shows only "+ New Project" (no MIDI import)
- [x] Full test suite passes (555/555)
- [x] Production build succeeds
- [x] Dev server loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)