### PR TITLE
Redesign workspace: grid-centered layout with unified toolbar

### DIFF
--- a/src/ui/components/panels/ActiveLayoutSummary.tsx
+++ b/src/ui/components/panels/ActiveLayoutSummary.tsx
@@ -1,0 +1,330 @@
+/**
+ * ActiveLayoutSummary.
+ *
+ * Right-column top section showing the current layout status, scores,
+ * constraint satisfaction, and contextual event details when an event
+ * is selected.
+ */
+
+import { useState, useMemo } from 'react';
+import { useProject } from '../../state/ProjectContext';
+import { getDisplayedLayout, getDisplayedLayoutRole, getActiveStreams } from '../../state/projectState';
+import { type FingerType, ALL_FINGERS } from '../../../types/fingerModel';
+import { CostBreakdownBars } from './CostBreakdownBars';
+import { EventCostChart } from './EventCostChart';
+import { LearnMoreModal } from './LearnMoreModal';
+import { buildSelectedTransitionModel } from '../../analysis/selectionModel';
+
+/** Parse a constraint string like "L-Ix" into hand + finger. */
+function parseConstraint(constraint: string): { hand: 'left' | 'right'; finger: FingerType } | null {
+  const FINGER_MAP: Record<string, FingerType> = {
+    Th: 'thumb', Ix: 'index', Md: 'middle', Rg: 'ring', Pk: 'pinky',
+  };
+  const match = constraint.match(/^([LR])-(\w+)$/);
+  if (!match) return null;
+  const hand = match[1] === 'L' ? 'left' as const : 'right' as const;
+  const finger = FINGER_MAP[match[2]];
+  if (!finger) return null;
+  return { hand, finger };
+}
+
+/** Build a constraint string from hand + finger. */
+function buildConstraintStr(hand: 'left' | 'right', finger: FingerType): string {
+  const FINGER_ABBREV: Record<FingerType, string> = {
+    thumb: '1', index: '2', middle: '3', ring: '4', pinky: '5',
+  };
+  return `${hand === 'left' ? 'L' : 'R'}${FINGER_ABBREV[finger]}`;
+}
+
+export function ActiveLayoutSummary() {
+  const { state, dispatch } = useProject();
+  const [learnMoreOpen, setLearnMoreOpen] = useState(false);
+  const [chartOpen, setChartOpen] = useState(false);
+
+  const displayedLayout = getDisplayedLayout(state);
+  const layoutRole = getDisplayedLayoutRole(state);
+  const activeStreams = getActiveStreams(state);
+  const currentPlan = state.analysisResult?.executionPlan;
+  const assignments = currentPlan?.fingerAssignments;
+
+  // Selected event data
+  const assignment = useMemo(() => {
+    if (state.selectedEventIndex === null || !assignments) return null;
+    return assignments.find(a => a.eventIndex === state.selectedEventIndex) ?? null;
+  }, [state.selectedEventIndex, assignments]);
+
+  // Transition data
+  const transition = useMemo(
+    () => buildSelectedTransitionModel(assignments ?? null, state.selectedEventIndex),
+    [assignments, state.selectedEventIndex],
+  );
+
+  // Event detail helpers
+  const stream = assignment ? activeStreams.find(s => s.originalMidiNote === assignment.noteNumber) : null;
+  const padKey = assignment?.row !== undefined && assignment?.col !== undefined
+    ? `${assignment.row},${assignment.col}`
+    : null;
+  const currentConstraint = padKey && displayedLayout ? displayedLayout.fingerConstraints[padKey] : undefined;
+  const parsed = currentConstraint ? parseConstraint(currentConstraint) : null;
+  const effectiveHand = parsed?.hand ?? (assignment?.assignedHand === 'Unplayable' ? null : assignment?.assignedHand ?? null);
+  const effectiveFinger = parsed?.finger ?? assignment?.finger ?? null;
+
+  const handleSetConstraint = (hand: 'left' | 'right', finger: FingerType) => {
+    if (!padKey) return;
+    dispatch({ type: 'SET_FINGER_CONSTRAINT', payload: { padKey, constraint: buildConstraintStr(hand, finger) } });
+  };
+
+  const handleClearConstraint = () => {
+    if (!padKey) return;
+    dispatch({ type: 'SET_FINGER_CONSTRAINT', payload: { padKey, constraint: null } });
+  };
+
+  const mappedCount = displayedLayout ? Object.keys(displayedLayout.padToVoice).length : 0;
+
+  return (
+    <>
+      <div className="rounded-lg glass-panel flex flex-col overflow-hidden" style={{ maxHeight: '50vh' }}>
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800 flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-[11px] font-semibold text-gray-300 uppercase tracking-wider">Layout Summary</h3>
+            {state.analysisStale && currentPlan && (
+              <span className="w-2 h-2 rounded-full bg-amber-400 animate-pulse" title="Analysis outdated" />
+            )}
+          </div>
+          <button
+            className="text-[10px] text-cyan-400 hover:text-cyan-300 transition-colors"
+            onClick={() => setLearnMoreOpen(true)}
+          >
+            Learn more
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-3 py-3 space-y-3">
+          {/* Layout identity */}
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] text-gray-200 font-medium truncate">
+              {displayedLayout?.name ?? 'No Layout'}
+            </span>
+            <span className={`text-[9px] px-1.5 py-0.5 rounded font-medium ${
+              layoutRole === 'working'
+                ? 'bg-amber-500/15 text-amber-400'
+                : 'bg-emerald-500/15 text-emerald-400'
+            }`}>
+              {layoutRole === 'working' ? 'Draft' : 'Active'}
+            </span>
+          </div>
+
+          {/* Quick stats */}
+          {currentPlan ? (
+            <div className="grid grid-cols-4 gap-1.5">
+              <QuickStat
+                label="Score"
+                value={currentPlan.score.toFixed(1)}
+                quality={currentPlan.score < 5 ? 'good' : currentPlan.score < 15 ? 'ok' : 'bad'}
+              />
+              <QuickStat
+                label="Events"
+                value={String(new Set(currentPlan.fingerAssignments.map(a => a.startTime)).size)}
+              />
+              <QuickStat
+                label="Hard"
+                value={String(currentPlan.hardCount)}
+                quality={currentPlan.hardCount === 0 ? 'good' : 'bad'}
+              />
+              <QuickStat
+                label="Unplay"
+                value={String(currentPlan.unplayableCount)}
+                quality={currentPlan.unplayableCount === 0 ? 'good' : 'bad'}
+              />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-1.5">
+              <QuickStat label="Mapped" value={`${mappedCount} pads`} />
+              <QuickStat label="Sounds" value={String(activeStreams.length)} />
+            </div>
+          )}
+
+          {/* Feasibility */}
+          {currentPlan && (
+            <div className="flex items-center gap-2 text-[10px]">
+              <span className={`w-2 h-2 rounded-full ${
+                currentPlan.unplayableCount === 0 ? 'bg-green-400' : 'bg-red-400'
+              }`} />
+              <span className="text-gray-400">
+                {currentPlan.unplayableCount === 0
+                  ? 'All events playable'
+                  : `${currentPlan.unplayableCount} unplayable event${currentPlan.unplayableCount !== 1 ? 's' : ''}`}
+              </span>
+            </div>
+          )}
+
+          {/* Cost breakdown bars */}
+          {currentPlan && (
+            <CostBreakdownBars metrics={currentPlan.averageMetrics} />
+          )}
+
+          {/* Event difficulty chart (collapsible) */}
+          {currentPlan && currentPlan.fingerAssignments.length > 0 && (
+            <div>
+              <button
+                className="flex items-center gap-1.5 text-[10px] text-gray-500 hover:text-gray-300 transition-colors mb-1"
+                onClick={() => setChartOpen(!chartOpen)}
+              >
+                <span>{chartOpen ? '\u25BE' : '\u25B8'}</span>
+                Event Difficulty Chart
+              </button>
+              {chartOpen && (
+                <EventCostChart fingerAssignments={currentPlan.fingerAssignments} />
+              )}
+            </div>
+          )}
+
+          {/* ─── Selected Event Details ─────────────────────────── */}
+          {assignment && (
+            <div className="pt-2 border-t border-gray-700/50 space-y-2">
+              <div className="flex items-center justify-between">
+                <h4 className="text-[10px] text-gray-500 font-medium uppercase tracking-wider">Selected Event</h4>
+                <button
+                  className="text-[10px] text-gray-500 hover:text-gray-300"
+                  onClick={() => dispatch({ type: 'SELECT_EVENT', payload: null })}
+                >
+                  Deselect
+                </button>
+              </div>
+
+              <div className="grid grid-cols-3 gap-1.5 text-[10px]">
+                <DetailChip label="Sound" value={stream?.name ?? `Note ${assignment.noteNumber}`} />
+                <DetailChip label="Time" value={`${assignment.startTime.toFixed(3)}s`} />
+                <DetailChip label="Pad" value={padKey ?? '—'} />
+                <DetailChip
+                  label="Hand"
+                  value={effectiveHand ?? 'Unplayable'}
+                  color={effectiveHand === 'left' ? 'text-blue-300' : effectiveHand === 'right' ? 'text-orange-300' : 'text-red-400'}
+                />
+                <DetailChip label="Finger" value={effectiveFinger ?? 'none'} />
+                <DetailChip label="Cost" value={assignment.cost.toFixed(2)} />
+              </div>
+
+              {/* Finger constraint controls */}
+              {padKey && (
+                <div className="space-y-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[9px] text-gray-500 w-10">Hand:</span>
+                    <div className="flex gap-1">
+                      {(['left', 'right'] as const).map(hand => (
+                        <button
+                          key={hand}
+                          className={`px-2 py-0.5 text-[10px] rounded transition-colors ${
+                            effectiveHand === hand
+                              ? hand === 'left' ? 'bg-blue-600/30 text-blue-300 border border-blue-500' : 'bg-orange-600/30 text-orange-300 border border-orange-500'
+                              : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+                          }`}
+                          onClick={() => handleSetConstraint(hand, effectiveFinger ?? 'index')}
+                        >
+                          {hand === 'left' ? 'L' : 'R'}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex gap-1 ml-2">
+                      {ALL_FINGERS.map(finger => (
+                        <button
+                          key={finger}
+                          className={`px-1.5 py-0.5 text-[10px] rounded transition-colors ${
+                            effectiveFinger === finger
+                              ? 'bg-gray-600 text-gray-200 border border-gray-500'
+                              : 'bg-gray-800 text-gray-500 border border-gray-700 hover:text-gray-300'
+                          }`}
+                          onClick={() => handleSetConstraint(effectiveHand ?? 'right', finger)}
+                        >
+                          {finger.slice(0, 2).toUpperCase()}
+                        </button>
+                      ))}
+                    </div>
+                    {currentConstraint && (
+                      <button
+                        className="text-[9px] text-amber-400 hover:text-amber-300 ml-auto"
+                        onClick={handleClearConstraint}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* ─── Transition Details ─────────────────────────────── */}
+          {transition && transition.next && (
+            <div className="pt-2 border-t border-gray-700/50 space-y-2">
+              <h4 className="text-[10px] text-gray-500 font-medium uppercase tracking-wider">Transition</h4>
+              <div className="grid grid-cols-4 gap-1.5">
+                <DetailChip label="Delta" value={`${transition.timeDelta?.toFixed(3)}s`} />
+                <DetailChip label="Holds" value={String(transition.sharedPadKeys.size)} />
+                <DetailChip label="Moves" value={String(transition.fingerMoves.filter(m => m.fromPad && m.toPad && !m.isHold).length)} />
+                <DetailChip label="Paths" value={String(transition.fingerMoves.length)} />
+              </div>
+              {transition.fingerMoves.length > 0 && (
+                <div className="space-y-0.5">
+                  {transition.fingerMoves.slice(0, 5).map(move => (
+                    <div key={`${move.hand}-${move.finger}-${move.fromPad}-${move.toPad}`} className="flex items-center justify-between text-[10px]">
+                      <span className={move.hand === 'left' ? 'text-blue-300' : 'text-orange-300'}>
+                        {move.hand[0].toUpperCase()}-{move.finger.slice(0, 2).toUpperCase()}
+                      </span>
+                      <span className="text-gray-500">
+                        {move.fromPad ?? '—'} → {move.toPad ?? '—'}
+                      </span>
+                      <span className="text-gray-600 font-mono text-[9px]">
+                        {move.isHold ? 'hold' : move.rawDistance?.toFixed(1) ?? 'new'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!currentPlan && !state.isProcessing && (
+            <div className="text-[10px] text-gray-600 py-2 text-center">
+              Assign sounds to pads, then <strong className="text-gray-400">Generate</strong> to analyze.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <LearnMoreModal open={learnMoreOpen} onClose={() => setLearnMoreOpen(false)} />
+    </>
+  );
+}
+
+function QuickStat({ label, value, quality }: {
+  label: string;
+  value: string;
+  quality?: 'good' | 'ok' | 'bad';
+}) {
+  const colors = {
+    good: 'text-green-400 border-green-500/20 bg-green-500/5',
+    ok: 'text-gray-300 border-gray-700 bg-gray-800/50',
+    bad: 'text-red-400 border-red-500/20 bg-red-500/5',
+  };
+  const style = quality ? colors[quality] : 'text-gray-300 border-gray-700 bg-gray-800/50';
+
+  return (
+    <div className={`px-2 py-1 rounded border text-center ${style}`}>
+      <div className="text-[8px] text-gray-500 uppercase">{label}</div>
+      <div className="text-[11px] font-mono font-medium">{value}</div>
+    </div>
+  );
+}
+
+function DetailChip({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="rounded border border-gray-700/60 bg-gray-900/40 px-2 py-1">
+      <div className="text-[8px] text-gray-500 uppercase">{label}</div>
+      <div className={`text-[10px] font-medium ${color ?? 'text-gray-200'}`}>{value}</div>
+    </div>
+  );
+}

--- a/src/ui/components/panels/CandidatePreviewCard.tsx
+++ b/src/ui/components/panels/CandidatePreviewCard.tsx
@@ -2,7 +2,7 @@
  * CandidatePreviewCard.
  *
  * Compact preview of a candidate solution with mini grid,
- * summary metadata, and action buttons.
+ * summary metadata, selection checkbox for compare, and action buttons.
  */
 
 import { type CandidateSolution } from '../../../types/candidateSolution';
@@ -14,9 +14,10 @@ interface CandidatePreviewCardProps {
   soundStreams: SoundStream[];
   rank: number;
   isSelected: boolean;
+  isCheckedForCompare: boolean;
   onSelect: () => void;
   onPromote: () => void;
-  onCompare: () => void;
+  onToggleCompare: () => void;
 }
 
 function difficultyLabel(score: number): string {
@@ -49,35 +50,53 @@ export function CandidatePreviewCard({
   soundStreams,
   rank,
   isSelected,
+  isCheckedForCompare,
   onSelect,
   onPromote,
-  onCompare,
+  onToggleCompare,
 }: CandidatePreviewCardProps) {
   const overall = candidate.difficultyAnalysis.overallScore;
   const topDriver = topCostDriver(candidate.executionPlan.averageMetrics);
 
   return (
     <div
-      className={`rounded-lg border transition-all cursor-pointer ${
+      className={`rounded-lg border transition-all cursor-pointer relative ${
         isSelected
           ? 'border-blue-500 bg-blue-500/5 ring-1 ring-blue-500/20'
           : 'border-gray-700/60 bg-gray-800/30 hover:border-gray-600'
       }`}
       onClick={onSelect}
     >
+      {/* Compare checkbox */}
+      <button
+        className={`absolute top-1.5 left-1.5 z-10 w-4 h-4 rounded border flex items-center justify-center transition-all ${
+          isCheckedForCompare
+            ? 'bg-purple-600 border-purple-500 text-white'
+            : 'bg-gray-800/80 border-gray-600 text-transparent hover:border-gray-400'
+        }`}
+        onClick={e => { e.stopPropagation(); onToggleCompare(); }}
+        title="Select for comparison"
+      >
+        {isCheckedForCompare && (
+          <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z" />
+          </svg>
+        )}
+      </button>
+
       <div className="p-2.5">
         {/* Top row: rank + difficulty */}
         <div className="flex items-center justify-between mb-2">
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 ml-5">
             <span className="text-[10px] bg-gray-700/70 text-gray-400 px-1.5 py-0.5 rounded font-mono">
               #{rank}
             </span>
-            <span className="text-[11px] text-gray-400 truncate max-w-[80px]">
-              {candidate.metadata.strategy ?? `Candidate`}
+            <span className="text-[10px] text-gray-400 truncate max-w-[60px]">
+              {candidate.metadata.strategy ?? 'Candidate'}
             </span>
           </div>
           <span
-            className="text-[11px] font-mono font-medium"
+            className="text-[10px] font-mono font-medium"
             style={{ color: difficultyColor(overall) }}
           >
             {difficultyLabel(overall)}
@@ -99,7 +118,7 @@ export function CandidatePreviewCard({
           <span>Top: {topDriver}</span>
         </div>
 
-        {/* Feasibility warning with reason summary */}
+        {/* Feasibility warning */}
         {candidate.executionPlan.unplayableCount > 0 && (
           <div className="text-[10px] text-red-400 bg-red-500/10 rounded px-1.5 py-0.5 mb-2">
             {candidate.executionPlan.unplayableCount} unplayable
@@ -122,16 +141,16 @@ export function CandidatePreviewCard({
         {/* Action buttons */}
         <div className="flex gap-1.5">
           <button
-            className="flex-1 px-2 py-1 text-[10px] rounded transition-colors bg-green-600/15 border border-green-500/30 text-green-400 hover:bg-green-600/25"
-            onClick={e => { e.stopPropagation(); onPromote(); }}
+            className="flex-1 px-2 py-1 text-[10px] rounded transition-colors bg-blue-600/15 border border-blue-500/30 text-blue-400 hover:bg-blue-600/25"
+            onClick={e => { e.stopPropagation(); onSelect(); }}
           >
-            Promote to Active
+            Load
           </button>
           <button
-            className="px-2 py-1 text-[10px] rounded transition-colors bg-gray-800 border border-gray-700 text-gray-400 hover:text-gray-300 hover:bg-gray-700"
-            onClick={e => { e.stopPropagation(); onCompare(); }}
+            className="flex-1 px-2 py-1 text-[10px] rounded transition-colors bg-emerald-600/15 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-600/25"
+            onClick={e => { e.stopPropagation(); onPromote(); }}
           >
-            Compare
+            Promote
           </button>
         </div>
       </div>

--- a/src/ui/components/panels/CompareModal.tsx
+++ b/src/ui/components/panels/CompareModal.tsx
@@ -1,0 +1,209 @@
+/**
+ * CompareModal.
+ *
+ * Full overlay for comparing two candidate solutions side-by-side.
+ * Shows grids, tradeoff metrics, scores, and allows promoting.
+ */
+
+import { useState } from 'react';
+import { useProject } from '../../state/ProjectContext';
+import { CompareGridView } from '../CompareGridView';
+import { CandidateCompare } from '../CandidateCompare';
+import { MiniGridPreview } from './MiniGridPreview';
+import { type CandidateSolution } from '../../../types/candidateSolution';
+
+interface CompareModalProps {
+  candidateIds: string[];
+  onClose: () => void;
+}
+
+export function CompareModal({ candidateIds, onClose }: CompareModalProps) {
+  const { state, dispatch } = useProject();
+
+  // Find candidates from IDs
+  const allCandidates = state.candidates;
+  const comparableCandidates = candidateIds
+    .map(id => allCandidates.find(c => c.id === id))
+    .filter((c): c is CandidateSolution => c !== undefined);
+
+  // Allow picking which two to compare if more than 2 selected
+  const [leftIdx, setLeftIdx] = useState(0);
+  const [rightIdx, setRightIdx] = useState(Math.min(1, comparableCandidates.length - 1));
+
+  const candidateA = comparableCandidates[leftIdx] ?? null;
+  const candidateB = comparableCandidates[rightIdx] ?? null;
+
+  if (!candidateA || !candidateB) {
+    return (
+      <>
+        <div className="fixed inset-0 z-[70] bg-black/60" onClick={onClose} />
+        <div className="fixed inset-8 z-[71] rounded-xl border border-gray-700 bg-gray-900 shadow-2xl flex items-center justify-center">
+          <div className="text-gray-500 text-sm">Not enough candidates to compare.</div>
+        </div>
+      </>
+    );
+  }
+
+  const handlePromote = (candidate: CandidateSolution) => {
+    if (confirm('Promote this candidate to become the Active Layout?')) {
+      dispatch({ type: 'PROMOTE_CANDIDATE', payload: { candidateId: candidate.id } });
+      onClose();
+    }
+  };
+
+  const globalIdxA = allCandidates.indexOf(candidateA) + 1;
+  const globalIdxB = allCandidates.indexOf(candidateB) + 1;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[70] bg-black/60" onClick={onClose} />
+      <div className="fixed inset-6 z-[71] rounded-xl border border-gray-700 bg-gray-900 shadow-2xl flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-800 flex-shrink-0">
+          <h3 className="text-sm font-semibold text-gray-200">Compare Layouts</h3>
+          <div className="flex items-center gap-3">
+            {comparableCandidates.length > 2 && (
+              <div className="flex items-center gap-2 text-[11px] text-gray-400">
+                <span>Left:</span>
+                <select
+                  className="bg-gray-800 border border-gray-700 text-gray-300 text-[11px] rounded px-1 py-0.5"
+                  value={leftIdx}
+                  onChange={e => setLeftIdx(Number(e.target.value))}
+                >
+                  {comparableCandidates.map((c, i) => (
+                    <option key={c.id} value={i} disabled={i === rightIdx}>
+                      #{allCandidates.indexOf(c) + 1} {c.metadata.strategy ?? 'Candidate'}
+                    </option>
+                  ))}
+                </select>
+                <span>Right:</span>
+                <select
+                  className="bg-gray-800 border border-gray-700 text-gray-300 text-[11px] rounded px-1 py-0.5"
+                  value={rightIdx}
+                  onChange={e => setRightIdx(Number(e.target.value))}
+                >
+                  {comparableCandidates.map((c, i) => (
+                    <option key={c.id} value={i} disabled={i === leftIdx}>
+                      #{allCandidates.indexOf(c) + 1} {c.metadata.strategy ?? 'Candidate'}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+            <button className="text-gray-500 hover:text-gray-300 text-lg transition-colors" onClick={onClose}>&times;</button>
+          </div>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-6">
+          {/* Side-by-side grids */}
+          <CompareGridView
+            candidateA={candidateA}
+            candidateB={candidateB}
+            voices={state.soundStreams}
+            candidateAIndex={globalIdxA}
+            candidateBIndex={globalIdxB}
+          />
+
+          {/* Tradeoff comparison */}
+          <CandidateCompare candidateA={candidateA} candidateB={candidateB} />
+
+          {/* Score comparison table */}
+          <div className="grid grid-cols-2 gap-4">
+            <ComparisonCard
+              candidate={candidateA}
+              label={`#${globalIdxA} ${candidateA.metadata.strategy ?? 'Candidate'}`}
+              onPromote={() => handlePromote(candidateA)}
+            />
+            <ComparisonCard
+              candidate={candidateB}
+              label={`#${globalIdxB} ${candidateB.metadata.strategy ?? 'Candidate'}`}
+              onPromote={() => handlePromote(candidateB)}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ComparisonCard({
+  candidate,
+  label,
+  onPromote,
+}: {
+  candidate: CandidateSolution;
+  label: string;
+  onPromote: () => void;
+}) {
+  const plan = candidate.executionPlan;
+  const diff = candidate.difficultyAnalysis;
+
+  return (
+    <div className="rounded-lg border border-gray-700/60 bg-gray-800/30 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium text-gray-200">{label}</span>
+        <span className={`text-[11px] font-mono font-medium ${
+          diff.overallScore <= 0.2 ? 'text-green-400' :
+          diff.overallScore <= 0.45 ? 'text-yellow-400' :
+          diff.overallScore <= 0.7 ? 'text-orange-400' : 'text-red-400'
+        }`}>
+          {diff.overallScore <= 0.2 ? 'Easy' :
+           diff.overallScore <= 0.45 ? 'Moderate' :
+           diff.overallScore <= 0.7 ? 'Hard' : 'Extreme'}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-[10px]">
+        <div className="rounded bg-gray-900/40 px-2 py-1.5">
+          <div className="text-[9px] text-gray-500 uppercase">Score</div>
+          <div className="text-gray-200 font-mono">{plan.score.toFixed(1)}</div>
+        </div>
+        <div className="rounded bg-gray-900/40 px-2 py-1.5">
+          <div className="text-[9px] text-gray-500 uppercase">Unplayable</div>
+          <div className={`font-mono ${plan.unplayableCount === 0 ? 'text-green-400' : 'text-red-400'}`}>
+            {plan.unplayableCount}
+          </div>
+        </div>
+        <div className="rounded bg-gray-900/40 px-2 py-1.5">
+          <div className="text-[9px] text-gray-500 uppercase">Hard Events</div>
+          <div className="text-gray-200 font-mono">{plan.hardCount}</div>
+        </div>
+        <div className="rounded bg-gray-900/40 px-2 py-1.5">
+          <div className="text-[9px] text-gray-500 uppercase">Balance</div>
+          <div className="text-gray-200 font-mono">{candidate.tradeoffProfile.handBalance.toFixed(2)}</div>
+        </div>
+      </div>
+
+      {/* Tradeoff bars */}
+      <div className="space-y-1">
+        {([
+          ['Playability', candidate.tradeoffProfile.playability],
+          ['Compactness', candidate.tradeoffProfile.compactness],
+          ['Balance', candidate.tradeoffProfile.handBalance],
+          ['Transitions', candidate.tradeoffProfile.transitionEfficiency],
+        ] as const).map(([label, value]) => (
+          <div key={label} className="flex items-center gap-2">
+            <span className="text-[9px] text-gray-500 w-16">{label}</span>
+            <div className="flex-1 h-1.5 bg-gray-700/50 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-blue-500/60 rounded-full"
+                style={{ width: `${(value * 100).toFixed(0)}%` }}
+              />
+            </div>
+            <span className="text-[9px] text-gray-400 font-mono w-7 text-right">
+              {(value * 100).toFixed(0)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <button
+        className="w-full px-3 py-1.5 text-[11px] rounded bg-emerald-600/20 border border-emerald-500/30 text-emerald-400 hover:bg-emerald-600/30 transition-colors font-medium"
+        onClick={onPromote}
+      >
+        Promote to Active
+      </button>
+    </div>
+  );
+}

--- a/src/ui/components/panels/LayoutOptionsPanel.tsx
+++ b/src/ui/components/panels/LayoutOptionsPanel.tsx
@@ -1,0 +1,185 @@
+/**
+ * LayoutOptionsPanel.
+ *
+ * Right-column bottom section showing candidate solutions as selectable
+ * cards with mini grid previews. Supports multi-select for comparison.
+ */
+
+import { useState } from 'react';
+import { useProject } from '../../state/ProjectContext';
+import { CandidatePreviewCard } from './CandidatePreviewCard';
+
+interface LayoutOptionsPanelProps {
+  selectedForCompare: Set<string>;
+  onToggleCompare: (id: string) => void;
+  onCompare: () => void;
+}
+
+export function LayoutOptionsPanel({
+  selectedForCompare,
+  onToggleCompare,
+  onCompare,
+}: LayoutOptionsPanelProps) {
+  const { state, dispatch } = useProject();
+  const [viewAllOpen, setViewAllOpen] = useState(false);
+
+  const hasCandidates = state.candidates.length > 0;
+  const compareCount = selectedForCompare.size;
+
+  return (
+    <div className="rounded-lg glass-panel flex flex-col overflow-hidden flex-1 min-h-0">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800 flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <h3 className="text-[11px] font-semibold text-gray-300 uppercase tracking-wider">
+            Layout Options
+          </h3>
+          {hasCandidates && (
+            <span className="text-[10px] text-gray-500">{state.candidates.length}</span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {compareCount >= 2 && (
+            <button
+              className="px-2 py-0.5 text-[10px] rounded bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+              onClick={onCompare}
+            >
+              Compare ({compareCount})
+            </button>
+          )}
+          {state.candidates.length > 4 && (
+            <button
+              className="text-[10px] text-gray-500 hover:text-gray-300 transition-colors"
+              onClick={() => setViewAllOpen(true)}
+            >
+              View all
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto px-3 py-3">
+        {/* Empty state */}
+        {!hasCandidates && !state.isProcessing && (
+          <div className="text-[10px] text-gray-600 py-6 text-center">
+            Click <strong className="text-gray-400">Generate</strong> to create candidate layouts.
+          </div>
+        )}
+
+        {/* Processing state */}
+        {state.isProcessing && (
+          <div className="text-[10px] text-blue-400 py-6 text-center animate-pulse">
+            Generating candidates...
+          </div>
+        )}
+
+        {/* Candidate grid */}
+        {hasCandidates && (
+          <div className="grid grid-cols-2 gap-2">
+            {state.candidates.map((candidate, idx) => (
+              <CandidatePreviewCard
+                key={candidate.id}
+                candidate={candidate}
+                soundStreams={state.soundStreams}
+                rank={idx + 1}
+                isSelected={candidate.id === state.selectedCandidateId}
+                isCheckedForCompare={selectedForCompare.has(candidate.id)}
+                onSelect={() => {
+                  dispatch({ type: 'SELECT_CANDIDATE', payload: candidate.id });
+                  dispatch({ type: 'SET_ANALYSIS_RESULT', payload: candidate });
+                }}
+                onPromote={() => {
+                  if (confirm('Promote this candidate to become the Active Layout? The current active layout will be auto-saved as a variant.')) {
+                    dispatch({ type: 'PROMOTE_CANDIDATE', payload: { candidateId: candidate.id } });
+                  }
+                }}
+                onToggleCompare={() => onToggleCompare(candidate.id)}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Saved variants */}
+        {state.savedVariants.length > 0 && (
+          <div className="text-[10px] text-gray-600 pt-3 mt-3 border-t border-gray-800">
+            {state.savedVariants.length} saved variant{state.savedVariants.length !== 1 ? 's' : ''}
+          </div>
+        )}
+      </div>
+
+      {/* View All Modal */}
+      {viewAllOpen && (
+        <ViewAllOverlay
+          onClose={() => setViewAllOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ViewAllOverlay({ onClose }: { onClose: () => void }) {
+  const { state, dispatch } = useProject();
+
+  return (
+    <>
+      <div className="fixed inset-0 z-[60] bg-black/50" onClick={onClose} />
+      <div className="fixed inset-8 z-[61] rounded-xl border border-gray-700 bg-gray-900 shadow-2xl flex flex-col overflow-hidden max-w-3xl mx-auto">
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-800">
+          <h3 className="text-sm font-semibold text-gray-200">All Candidates & Variants</h3>
+          <button className="text-gray-500 hover:text-gray-300 text-lg" onClick={onClose}>&times;</button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-5">
+          {state.candidates.length > 0 && (
+            <div className="mb-6">
+              <h4 className="text-xs text-gray-400 font-medium uppercase tracking-wider mb-3">
+                Generated Candidates ({state.candidates.length})
+              </h4>
+              <div className="grid grid-cols-3 gap-3">
+                {state.candidates.map((c, idx) => (
+                  <CandidatePreviewCard
+                    key={c.id}
+                    candidate={c}
+                    soundStreams={state.soundStreams}
+                    rank={idx + 1}
+                    isSelected={c.id === state.selectedCandidateId}
+                    isCheckedForCompare={false}
+                    onSelect={() => {
+                      dispatch({ type: 'SELECT_CANDIDATE', payload: c.id });
+                      dispatch({ type: 'SET_ANALYSIS_RESULT', payload: c });
+                    }}
+                    onPromote={() => {}}
+                    onToggleCompare={() => {}}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {state.savedVariants.length > 0 && (
+            <div>
+              <h4 className="text-xs text-gray-400 font-medium uppercase tracking-wider mb-3">
+                Saved Variants ({state.savedVariants.length})
+              </h4>
+              <div className="grid grid-cols-3 gap-3">
+                {state.savedVariants.map((variant) => (
+                  <div key={variant.id} className="rounded-lg border border-gray-700/60 bg-gray-800/30 p-3">
+                    <div className="text-[11px] text-gray-300 font-medium mb-1 truncate">{variant.name}</div>
+                    <div className="text-[10px] text-gray-600">
+                      {Object.keys(variant.padToVoice).length} pads assigned
+                    </div>
+                    {variant.savedAt && (
+                      <div className="text-[10px] text-gray-600">
+                        Saved: {new Date(variant.savedAt).toLocaleDateString()}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/ui/components/panels/MiniGridPreview.tsx
+++ b/src/ui/components/panels/MiniGridPreview.tsx
@@ -18,7 +18,7 @@ interface MiniGridPreviewProps {
 }
 
 export function MiniGridPreview({ layout, soundStreams, size = 1, highlighted = false }: MiniGridPreviewProps) {
-  const cellSize = Math.round(14 * size);
+  const cellSize = Math.round(18 * size);
   const gap = 1;
   const gridSize = cellSize * 8 + gap * 7;
 

--- a/src/ui/components/workspace/PerformanceWorkspace.tsx
+++ b/src/ui/components/workspace/PerformanceWorkspace.tsx
@@ -1,224 +1,114 @@
-import { useState, useRef, useCallback } from 'react';
+/**
+ * PerformanceWorkspace.
+ *
+ * Redesigned workspace centered around three focal points:
+ * 1. The Push grid (large, dominant, center)
+ * 2. The timeline (directly below grid, tightly coupled)
+ * 3. Layout options (right column with mini grid previews)
+ *
+ * Layout: full-viewport 3-column with unified top toolbar.
+ * - Left: tabbed Sounds/Events panel
+ * - Center: Grid + Timeline stacked
+ * - Right: ActiveLayoutSummary + LayoutOptionsPanel
+ * - Bottom drawer: Pattern Composer (collapsible)
+ */
+
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useProject } from '../../state/ProjectContext';
+import { useAutoAnalysis } from '../../hooks/useAutoAnalysis';
+import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import { useViewSettings } from '../../state/viewSettings';
-import { saveProject } from '../../persistence/projectStorage';
-import { EditorToolbar } from '../EditorToolbar';
+
+import { WorkspaceToolbar } from './WorkspaceToolbar';
 import { VoicePalette } from '../VoicePalette';
 import { EventsPanel } from '../EventsPanel';
 import { InteractiveGrid } from '../InteractiveGrid';
-import { CompareGridView } from '../CompareGridView';
-import { PerformanceAnalysisPanel } from '../panels/PerformanceAnalysisPanel';
-import { EventDetailPanel } from '../EventDetailPanel';
-import { TransitionDetailPanel } from './TransitionDetailPanel';
 import { UnifiedTimeline } from '../UnifiedTimeline';
 import { WorkspacePatternStudio } from './WorkspacePatternStudio';
-
-import { SettingsGear } from '../panels/SettingsGear';
-import { useAutoAnalysis } from '../../hooks/useAutoAnalysis';
-import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
+import { ActiveLayoutSummary } from '../panels/ActiveLayoutSummary';
+import { LayoutOptionsPanel } from '../panels/LayoutOptionsPanel';
+import { CompareModal } from '../panels/CompareModal';
 
 type LeftPanelTab = 'sounds' | 'events';
-type BottomTab = 'timeline' | 'composer';
 
 export function PerformanceWorkspace() {
   const { state, dispatch } = useProject();
   const navigate = useNavigate();
   const { generateFull, calculateCost, generationProgress, canGenerate, generateDisabledReason } = useAutoAnalysis();
   useKeyboardShortcuts();
-  const { settings: viewSettings, toggleGridLabel, toggleLayoutDisplay } = useViewSettings();
+  const { settings: viewSettings } = useViewSettings();
 
   const [leftCollapsed, setLeftCollapsed] = useState(false);
-  const [rightCollapsed, setRightCollapsed] = useState(true);
-  const [onionSkin, setOnionSkin] = useState(false);
   const [leftTab, setLeftTab] = useState<LeftPanelTab>('sounds');
-  const [bottomTab, setBottomTab] = useState<BottomTab>('timeline');
-  const [leftWidth, setLeftWidth] = useState(260);
-  const [rightWidth, setRightWidth] = useState(360);
-  const isResizing = useRef<'left' | 'right' | false>(false);
+  const [onionSkin, setOnionSkin] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
 
-  // Editable project name
-  const [editingName, setEditingName] = useState(false);
-  const [nameDraft, setNameDraft] = useState('');
-  const nameInputRef = useRef<HTMLInputElement>(null);
-
-  // Editable BPM
-  const [editingBpm, setEditingBpm] = useState(false);
-  const [bpmDraft, setBpmDraft] = useState('');
+  // Compare state
+  const [selectedForCompare, setSelectedForCompare] = useState<Set<string>>(new Set());
+  const [compareModalOpen, setCompareModalOpen] = useState(false);
 
   const assignments = state.analysisResult?.executionPlan.fingerAssignments;
-  const selectedCandidate = state.candidates.find(candidate => candidate.id === state.selectedCandidateId) ?? null;
-  const compareCandidate = state.candidates.find(candidate => candidate.id === state.compareCandidateId) ?? null;
-  const isCompareMode = !!selectedCandidate && !!compareCandidate;
+  const selectedCandidate = state.candidates.find(c => c.id === state.selectedCandidateId) ?? null;
 
-  // Wrap generateFull to auto-open the analysis panel after generation
+  // Wrap generateFull to auto-open analysis after generation
   const handleGenerate = useCallback(async (mode?: Parameters<typeof generateFull>[0]) => {
-    const count = await generateFull(mode);
-    if (count && count > 0) {
-      setRightCollapsed(false);
-    }
+    await generateFull(mode);
   }, [generateFull]);
 
-  const commitName = () => {
-    const trimmed = nameDraft.trim();
-    if (trimmed && trimmed !== state.name) {
-      dispatch({ type: 'RENAME_PROJECT', payload: trimmed });
-    }
-    setEditingName(false);
-  };
-
-  const commitBpm = () => {
-    const val = parseInt(bpmDraft, 10);
-    if (!isNaN(val) && val !== state.tempo) {
-      dispatch({ type: 'SET_TEMPO', payload: val });
-    }
-    setEditingBpm(false);
-  };
-
-  // Panel resize via drag handle (shared for left and right)
-  const handleResizeStart = useCallback((side: 'left' | 'right', e: React.MouseEvent) => {
-    e.preventDefault();
-    isResizing.current = side;
-    const startX = e.clientX;
-    const startWidth = side === 'left' ? leftWidth : rightWidth;
-
-    const onMouseMove = (ev: MouseEvent) => {
-      if (!isResizing.current) return;
-      const delta = ev.clientX - startX;
-      if (side === 'left') {
-        setLeftWidth(Math.max(200, Math.min(500, startWidth + delta)));
+  const handleToggleCompare = useCallback((id: string) => {
+    setSelectedForCompare(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
       } else {
-        // Right panel: dragging left increases width
-        setRightWidth(Math.max(280, Math.min(600, startWidth - delta)));
+        next.add(id);
       }
-    };
+      return next;
+    });
+  }, []);
 
-    const onMouseUp = () => {
-      isResizing.current = false;
-      document.removeEventListener('mousemove', onMouseMove);
-      document.removeEventListener('mouseup', onMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }, [leftWidth, rightWidth]);
-
-  // Build grid template columns for the 3-column layout
-  const leftCol = leftCollapsed ? '48px' : `${leftWidth}px`;
-  const rightCol = rightCollapsed ? '48px' : `${rightWidth}px`;
-  const gridCols = `${leftCol} minmax(0, 1fr) ${rightCol}`;
+  const handleOpenCompare = useCallback(() => {
+    if (selectedForCompare.size >= 2) {
+      setCompareModalOpen(true);
+    }
+  }, [selectedForCompare]);
 
   return (
-    <div className="max-w-[1600px] mx-auto space-y-3">
-      {/* ─── Header ─────────────────────────────────────────────────────── */}
-      <div className="flex items-center gap-3">
-        <button
-          className="px-2 py-1 text-xs rounded bg-gray-800 hover:bg-gray-700 text-gray-400"
-          onClick={() => {
-            saveProject(state);
-            navigate('/');
-          }}
-          title="Save and return to library"
-        >
-          &larr; Library
-        </button>
+    <div className="h-screen flex flex-col bg-[var(--bg-app)]">
+      {/* ─── Top Toolbar ──────────────────────────────────────── */}
+      <WorkspaceToolbar
+        onNavigateLibrary={() => navigate('/')}
+        generateFull={handleGenerate}
+        generationProgress={generationProgress}
+        canGenerate={canGenerate}
+        generateDisabledReason={generateDisabledReason ?? null}
+        compareCount={selectedForCompare.size}
+        onCompare={handleOpenCompare}
+        composerOpen={composerOpen}
+        onToggleComposer={() => setComposerOpen(!composerOpen)}
+      />
 
-        <div className="min-w-0">
-          {editingName ? (
-            <input
-              ref={nameInputRef}
-              className="text-sm font-medium text-gray-200 bg-gray-800 border border-gray-600 rounded px-1.5 py-0.5 outline-none focus:border-blue-500 w-48"
-              value={nameDraft}
-              onChange={e => setNameDraft(e.target.value)}
-              onBlur={commitName}
-              onKeyDown={e => {
-                if (e.key === 'Enter') commitName();
-                if (e.key === 'Escape') setEditingName(false);
-              }}
-              autoFocus
-            />
-          ) : (
-            <div
-              className="text-sm font-medium text-gray-200 truncate cursor-pointer hover:text-white transition-colors"
-              onDoubleClick={() => {
-                setNameDraft(state.name || 'Untitled');
-                setEditingName(true);
-              }}
-              title="Double-click to rename"
-            >
-              {state.name || 'Untitled'}
-            </div>
-          )}
-          <div className="text-[10px] text-gray-500 uppercase tracking-[0.2em] flex items-center gap-1">
-            Performance Workspace
-            {editingBpm ? (
-              <input
-                className="ml-2 w-14 text-[10px] normal-case tracking-normal text-gray-200 bg-gray-800 border border-gray-600 rounded px-1 py-0.5 outline-none focus:border-blue-500"
-                type="number"
-                min={20}
-                max={999}
-                value={bpmDraft}
-                onChange={e => setBpmDraft(e.target.value)}
-                onBlur={commitBpm}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') commitBpm();
-                  if (e.key === 'Escape') setEditingBpm(false);
-                }}
-                autoFocus
-              />
-            ) : (
-              <span
-                className="ml-2 normal-case tracking-normal text-gray-600 cursor-pointer hover:text-gray-400 transition-colors"
-                onDoubleClick={() => {
-                  setBpmDraft(String(state.tempo));
-                  setEditingBpm(true);
-                }}
-                title="Double-click to change BPM"
-              >
-                {state.tempo} BPM
-              </span>
-            )}
-          </div>
-        </div>
-
-        <div className="flex-1" />
-      </div>
-
-      {/* ─── Error Banner ───────────────────────────────────────────────── */}
+      {/* ─── Error Banner ─────────────────────────────────────── */}
       {state.error && (
-        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-sm">
-          {state.error}
+        <div className="mx-3 mt-2 p-2 rounded-lg bg-red-500/10 border border-red-500/30 text-red-400 text-[11px] flex items-center justify-between">
+          <span>{state.error}</span>
           <button
             className="ml-2 text-red-500 hover:text-red-400"
             onClick={() => dispatch({ type: 'SET_ERROR', payload: null })}
           >
-            ×
+            &times;
           </button>
         </div>
       )}
 
-      {/* ─── Editor Toolbar ─────────────────────────────────────────────── */}
-      <EditorToolbar
-        generateFull={handleGenerate}
-        generationProgress={generationProgress}
-        canGenerate={canGenerate}
-        generateDisabledReason={generateDisabledReason}
-      />
-
-      {/* ─── Main Grid: Left Sidebar + Center Content + Right Analysis ── */}
-      <div
-        className="grid gap-4 items-start"
-        style={{ gridTemplateColumns: gridCols }}
-      >
-        {/* Left Column: Collapsible Sidebar with Sounds/Events tabs */}
-        <div className="min-w-0 relative flex">
+      {/* ─── Main Body: 3-column ──────────────────────────────── */}
+      <div className="flex-1 flex gap-3 overflow-hidden p-3 min-h-0">
+        {/* Left Column: Tabbed Sounds / Events */}
+        <div className={`flex-shrink-0 flex flex-col ${leftCollapsed ? 'w-10' : 'w-[280px]'} transition-all`}>
           {leftCollapsed ? (
             <button
-              className="flex flex-col items-center gap-3 py-3 w-full cursor-pointer hover:bg-gray-800/30 rounded transition-colors"
+              className="flex flex-col items-center gap-3 py-4 w-full cursor-pointer hover:bg-gray-800/30 rounded-lg transition-colors h-full"
               onClick={() => setLeftCollapsed(false)}
               title="Expand sidebar"
             >
@@ -228,11 +118,11 @@ export function PerformanceWorkspace() {
               <span className="text-[10px] text-gray-600">&#9656;</span>
             </button>
           ) : (
-            <div className="rounded-lg glass-panel flex flex-col" style={{ height: 'calc(100vh - 220px)' }}>
+            <div className="rounded-lg glass-panel flex flex-col flex-1 min-h-0">
               {/* Tab header */}
               <div className="flex items-center border-b border-gray-800 flex-shrink-0">
                 <button
-                  className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+                  className={`flex-1 px-3 py-2 text-[11px] font-medium transition-colors ${
                     leftTab === 'sounds'
                       ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
                       : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
@@ -242,7 +132,7 @@ export function PerformanceWorkspace() {
                   Sounds
                 </button>
                 <button
-                  className={`flex-1 px-3 py-2 text-xs font-medium transition-colors ${
+                  className={`flex-1 px-3 py-2 text-[11px] font-medium transition-colors ${
                     leftTab === 'events'
                       ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
                       : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
@@ -260,8 +150,8 @@ export function PerformanceWorkspace() {
                 </button>
               </div>
 
-              {/* Tab content — scrollable */}
-              <div className="p-3 overflow-y-auto flex-1">
+              {/* Tab content */}
+              <div className="p-3 overflow-y-auto flex-1 min-h-0">
                 {leftTab === 'sounds' ? (
                   <VoicePalette />
                 ) : (
@@ -270,49 +160,13 @@ export function PerformanceWorkspace() {
               </div>
             </div>
           )}
-          {/* Drag handle for resizing */}
-          {!leftCollapsed && (
-            <div
-              className="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-blue-500/40 transition-colors z-10"
-              onMouseDown={(e) => handleResizeStart('left', e)}
-            />
-          )}
         </div>
 
-        {/* Center Column: Push Grid + Event Detail + Transition Detail */}
-        <div className="space-y-3 min-w-0">
-          <div className="p-3 rounded-lg glass-panel">
-            <div className="flex items-center justify-between mb-2">
-              <h3 className="text-sm font-medium text-gray-400">
-                {isCompareMode ? 'Layout Compare' : 'Push Grid'}
-              </h3>
-              <div className="flex items-center gap-2">
-                <SettingsGear
-                  gridLabels={viewSettings.gridLabels}
-                  layoutDisplay={viewSettings.layoutDisplay}
-                  onToggleGridLabel={toggleGridLabel}
-                  onToggleLayoutDisplay={toggleLayoutDisplay}
-                  onDuplicateLayout={() => {
-                    if (state.workingLayout) {
-                      dispatch({ type: 'SAVE_AS_VARIANT', payload: { name: `${state.workingLayout.name} copy`, source: 'working' } });
-                    } else {
-                      dispatch({ type: 'CREATE_WORKING_LAYOUT' });
-                      dispatch({ type: 'SAVE_AS_VARIANT', payload: { name: `${state.activeLayout.name} copy`, source: 'working' } });
-                      dispatch({ type: 'DISCARD_WORKING_LAYOUT' });
-                    }
-                  }}
-                />
-              </div>
-            </div>
-            {isCompareMode ? (
-              <CompareGridView
-                candidateA={selectedCandidate}
-                candidateB={compareCandidate}
-                voices={state.soundStreams}
-                candidateAIndex={state.candidates.indexOf(selectedCandidate) + 1}
-                candidateBIndex={state.candidates.indexOf(compareCandidate) + 1}
-              />
-            ) : (
+        {/* Center Column: Grid + Timeline stacked */}
+        <div className="flex-1 flex flex-col gap-3 min-w-0 min-h-0">
+          {/* Push Grid — takes available space */}
+          <div className="flex-1 min-h-0 rounded-lg glass-panel p-3 flex flex-col">
+            <div className="flex-1 min-h-0 flex items-center justify-center">
               <InteractiveGrid
                 assignments={assignments}
                 layoutOverride={selectedCandidate?.layout}
@@ -322,78 +176,51 @@ export function PerformanceWorkspace() {
                 voiceConstraints={state.voiceConstraints}
                 gridLabels={viewSettings.gridLabels}
               />
-            )}
+            </div>
           </div>
 
-          <EventDetailPanel />
-          <TransitionDetailPanel />
+          {/* Timeline — fixed height */}
+          <div className="h-[220px] flex-shrink-0 rounded-lg glass-panel overflow-hidden">
+            <UnifiedTimeline />
+          </div>
         </div>
 
-        {/* Right Column: Collapsible Analysis Panel */}
-        <div className="min-w-0 relative">
-          {rightCollapsed ? (
+        {/* Right Column: Summary + Options stacked */}
+        <div className="w-[340px] flex-shrink-0 flex flex-col gap-3 min-h-0">
+          <ActiveLayoutSummary />
+          <LayoutOptionsPanel
+            selectedForCompare={selectedForCompare}
+            onToggleCompare={handleToggleCompare}
+            onCompare={handleOpenCompare}
+          />
+        </div>
+      </div>
+
+      {/* ─── Pattern Composer Bottom Drawer ────────────────────── */}
+      {composerOpen && (
+        <div className="flex-shrink-0 border-t border-gray-800">
+          <div className="flex items-center gap-2 px-3 py-1.5 bg-gray-900/60">
+            <span className="text-[11px] text-gray-300 font-medium">Pattern Composer</span>
+            <div className="flex-1" />
+            <span className="text-[10px] text-gray-600">Create and edit rhythmic patterns</span>
             <button
-              className="flex flex-col items-center gap-3 py-3 w-full cursor-pointer hover:bg-gray-800/30 rounded transition-colors"
-              onClick={() => setRightCollapsed(false)}
-              title="Expand analysis panel"
+              className="text-[10px] text-gray-500 hover:text-gray-300 transition-colors"
+              onClick={() => setComposerOpen(false)}
             >
-              <span className="text-[10px] text-gray-500" style={{ writingMode: 'vertical-lr' }}>
-                Analysis
-              </span>
-              <span className="text-[10px] text-gray-600">&#9666;</span>
+              &times; Close
             </button>
-          ) : (
-            <>
-              <div className="rounded-lg glass-panel flex flex-col" style={{ height: 'calc(100vh - 220px)' }}>
-                <PerformanceAnalysisPanel
-                  onClose={() => setRightCollapsed(true)}
-                  calculateCost={calculateCost}
-                />
-              </div>
-              {/* Drag handle for resizing */}
-              <div
-                className="absolute top-0 left-0 w-1 h-full cursor-col-resize hover:bg-blue-500/40 transition-colors z-10"
-                onMouseDown={(e) => handleResizeStart('right', e)}
-              />
-            </>
-          )}
+          </div>
+          <WorkspacePatternStudio />
         </div>
-      </div>
+      )}
 
-      {/* ─── Bottom Drawer: Timeline / Pattern Composer ─────────────────── */}
-      <div className="rounded-lg glass-panel overflow-hidden">
-        <div className="flex items-center gap-1 px-3 py-2 border-b border-gray-800 bg-gray-900/40">
-          <button
-            className={`px-2 py-1 text-xs rounded transition-colors ${
-              bottomTab === 'timeline'
-                ? 'text-gray-200 bg-gray-800/60'
-                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
-            }`}
-            onClick={() => setBottomTab('timeline')}
-          >
-            Timeline
-          </button>
-          <button
-            className={`px-2 py-1 text-xs rounded transition-colors ${
-              bottomTab === 'composer'
-                ? 'text-gray-200 bg-gray-800/60'
-                : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
-            }`}
-            onClick={() => setBottomTab('composer')}
-          >
-            Pattern Composer
-          </button>
-          <div className="flex-1" />
-          <span className="text-[10px] text-gray-600">
-            {bottomTab === 'timeline'
-              ? 'Performance timeline with execution analysis'
-              : 'Create and edit rhythmic patterns'}
-          </span>
-        </div>
-        <div>
-          {bottomTab === 'timeline' ? <UnifiedTimeline /> : <WorkspacePatternStudio />}
-        </div>
-      </div>
+      {/* ─── Compare Modal ────────────────────────────────────── */}
+      {compareModalOpen && (
+        <CompareModal
+          candidateIds={Array.from(selectedForCompare)}
+          onClose={() => setCompareModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/ui/components/workspace/WorkspaceToolbar.tsx
+++ b/src/ui/components/workspace/WorkspaceToolbar.tsx
@@ -1,0 +1,340 @@
+/**
+ * WorkspaceToolbar.
+ *
+ * Unified top toolbar merging the old header + EditorToolbar into one
+ * concise, professional bar. Contains project identity, workflow actions,
+ * editing controls, generation, compare trigger, and settings.
+ */
+
+import { useState, useRef } from 'react';
+import { useProject } from '../../state/ProjectContext';
+import { saveProject, exportProjectToFile } from '../../persistence/projectStorage';
+import { getDisplayedLayout, getDisplayedLayoutRole, hasWorkingChanges } from '../../state/projectState';
+import { type GenerationMode } from '../../hooks/useAutoAnalysis';
+import { type OptimizerMethodKey } from '../../../engine/optimization/optimizerInterface';
+import { SettingsGear } from '../panels/SettingsGear';
+import { useViewSettings } from '../../state/viewSettings';
+
+interface WorkspaceToolbarProps {
+  onNavigateLibrary: () => void;
+  generateFull: (mode?: GenerationMode) => Promise<void>;
+  generationProgress: string | null;
+  canGenerate: boolean;
+  generateDisabledReason: string | null;
+  compareCount: number;
+  onCompare: () => void;
+  composerOpen: boolean;
+  onToggleComposer: () => void;
+}
+
+export function WorkspaceToolbar({
+  onNavigateLibrary,
+  generateFull,
+  generationProgress,
+  canGenerate,
+  generateDisabledReason,
+  compareCount,
+  onCompare,
+  composerOpen,
+  onToggleComposer,
+}: WorkspaceToolbarProps) {
+  const { state, dispatch, undo, redo, canUndo, canRedo } = useProject();
+  const { settings: viewSettings, toggleGridLabel, toggleLayoutDisplay } = useViewSettings();
+  const displayedLayout = getDisplayedLayout(state);
+  const layoutRole = getDisplayedLayoutRole(state);
+  const hasChanges = hasWorkingChanges(state);
+
+  // Editable project name
+  const [editingName, setEditingName] = useState(false);
+  const [nameDraft, setNameDraft] = useState('');
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  // Editable BPM
+  const [editingBpm, setEditingBpm] = useState(false);
+  const [bpmDraft, setBpmDraft] = useState('');
+
+  // Generation mode
+  const [generationMode, setGenerationMode] = useState<GenerationMode>('fast');
+
+  // Save confirmation
+  const [saveConfirm, setSaveConfirm] = useState(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commitName = () => {
+    const trimmed = nameDraft.trim();
+    if (trimmed && trimmed !== state.name) {
+      dispatch({ type: 'RENAME_PROJECT', payload: trimmed });
+    }
+    setEditingName(false);
+  };
+
+  const commitBpm = () => {
+    const val = parseInt(bpmDraft, 10);
+    if (!isNaN(val) && val !== state.tempo) {
+      dispatch({ type: 'SET_TEMPO', payload: val });
+    }
+    setEditingBpm(false);
+  };
+
+  const handleSave = () => {
+    saveProject(state);
+    setSaveConfirm(true);
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => setSaveConfirm(false), 1500);
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-800/80 bg-gray-900/60 flex-shrink-0">
+      {/* Library back */}
+      <button
+        className="px-2 py-1 text-[11px] rounded bg-gray-800 hover:bg-gray-700 text-gray-400 hover:text-gray-200 transition-colors"
+        onClick={() => {
+          saveProject(state);
+          onNavigateLibrary();
+        }}
+        title="Save and return to library"
+      >
+        &larr; Library
+      </button>
+
+      {/* Divider */}
+      <div className="w-px h-5 bg-gray-800" />
+
+      {/* Project name */}
+      <div className="min-w-0">
+        {editingName ? (
+          <input
+            ref={nameInputRef}
+            className="text-sm font-semibold text-gray-200 bg-gray-800 border border-gray-600 rounded px-1.5 py-0.5 outline-none focus:border-blue-500 w-48"
+            value={nameDraft}
+            onChange={e => setNameDraft(e.target.value)}
+            onBlur={commitName}
+            onKeyDown={e => {
+              if (e.key === 'Enter') commitName();
+              if (e.key === 'Escape') setEditingName(false);
+            }}
+            autoFocus
+          />
+        ) : (
+          <span
+            className="text-sm font-semibold text-gray-200 truncate cursor-pointer hover:text-white transition-colors"
+            onDoubleClick={() => {
+              setNameDraft(state.name || 'Untitled');
+              setEditingName(true);
+            }}
+            title="Double-click to rename"
+          >
+            {state.name || 'Untitled'}
+          </span>
+        )}
+      </div>
+
+      {/* BPM */}
+      {editingBpm ? (
+        <input
+          className="w-14 text-[11px] text-gray-200 bg-gray-800 border border-gray-600 rounded px-1.5 py-0.5 outline-none focus:border-blue-500"
+          type="number"
+          min={20}
+          max={999}
+          value={bpmDraft}
+          onChange={e => setBpmDraft(e.target.value)}
+          onBlur={commitBpm}
+          onKeyDown={e => {
+            if (e.key === 'Enter') commitBpm();
+            if (e.key === 'Escape') setEditingBpm(false);
+          }}
+          autoFocus
+        />
+      ) : (
+        <span
+          className="text-[11px] text-gray-500 cursor-pointer hover:text-gray-300 transition-colors tabular-nums"
+          onDoubleClick={() => {
+            setBpmDraft(String(state.tempo));
+            setEditingBpm(true);
+          }}
+          title="Double-click to change BPM"
+        >
+          {state.tempo} BPM
+        </span>
+      )}
+
+      {/* Layout status badge */}
+      {displayedLayout && (
+        <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+          layoutRole === 'working'
+            ? 'bg-amber-500/15 text-amber-400 border border-amber-500/30'
+            : 'bg-emerald-500/15 text-emerald-400 border border-emerald-500/30'
+        }`}>
+          {layoutRole === 'working' ? 'Working Draft' : 'Active'}
+        </span>
+      )}
+
+      {/* Workflow actions */}
+      {hasChanges && (
+        <>
+          <div className="w-px h-5 bg-gray-800" />
+          <div className="flex gap-1">
+            <button
+              className="px-2 py-1 text-[11px] rounded bg-emerald-600 hover:bg-emerald-500 text-white transition-colors"
+              onClick={() => dispatch({ type: 'PROMOTE_WORKING_LAYOUT' })}
+              title="Make this layout the new Active Layout"
+            >
+              Promote
+            </button>
+            <button
+              className="px-2 py-1 text-[11px] rounded bg-blue-600/80 hover:bg-blue-500 text-white transition-colors"
+              onClick={() => dispatch({ type: 'SAVE_AS_VARIANT', payload: { name: `${state.activeLayout.name} variant`, source: 'working' } })}
+              title="Save current working layout as a named variant"
+            >
+              Save Variant
+            </button>
+            <button
+              className="px-2 py-1 text-[11px] rounded bg-gray-800 hover:bg-red-900/50 text-gray-400 hover:text-red-300 transition-colors"
+              onClick={() => dispatch({ type: 'DISCARD_WORKING_LAYOUT' })}
+              title="Discard working changes"
+            >
+              Discard
+            </button>
+          </div>
+        </>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Analysis stale indicator */}
+      {state.analysisStale && state.analysisResult && (
+        <span className="text-[10px] text-amber-400 px-2 py-0.5 rounded bg-amber-500/10 border border-amber-500/20">
+          Analysis outdated
+        </span>
+      )}
+
+      {/* Undo / Redo */}
+      <div className="flex gap-1">
+        <button
+          className="px-2 py-1 text-[11px] rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          onClick={undo}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+        >
+          Undo
+        </button>
+        <button
+          className="px-2 py-1 text-[11px] rounded bg-gray-800 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          onClick={redo}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Y)"
+        >
+          Redo
+        </button>
+      </div>
+
+      {/* Save */}
+      <button
+        className={`px-2 py-1 text-[11px] rounded transition-colors ${
+          saveConfirm
+            ? 'bg-emerald-600/20 text-emerald-400 border border-emerald-500/30'
+            : 'bg-gray-800 hover:bg-gray-700 text-gray-300'
+        }`}
+        onClick={handleSave}
+        title="Save project"
+      >
+        {saveConfirm ? 'Saved' : 'Save'}
+      </button>
+
+      <div className="w-px h-5 bg-gray-800" />
+
+      {/* Generate */}
+      {state.isProcessing ? (
+        <span className="text-[11px] text-blue-400 animate-pulse px-2 py-1">
+          {generationProgress || 'Analyzing...'}
+        </span>
+      ) : (
+        <div className="flex items-center gap-1">
+          <select
+            className="bg-gray-800 border border-gray-700 text-gray-300 text-[11px] rounded px-1 py-1 cursor-pointer"
+            value={state.optimizerMethod}
+            onChange={(e) => dispatch({ type: 'SET_OPTIMIZER_METHOD', payload: e.target.value as OptimizerMethodKey })}
+            title="Optimizer method"
+          >
+            <option value="greedy">Greedy</option>
+            <option value="beam">Beam</option>
+            <option value="annealing">Annealing</option>
+          </select>
+
+          {state.optimizerMethod === 'annealing' && (
+            <select
+              className="bg-gray-800 border border-gray-700 text-gray-300 text-[11px] rounded px-1 py-1 cursor-pointer"
+              value={generationMode}
+              onChange={(e) => setGenerationMode(e.target.value as GenerationMode)}
+              title="Intensity"
+            >
+              <option value="fast">Quick</option>
+              <option value="deep">Thorough</option>
+              <option value="auto">Auto</option>
+            </select>
+          )}
+
+          <button
+            className={`px-3 py-1 rounded text-[11px] font-medium transition-colors ${
+              canGenerate
+                ? 'bg-blue-600 hover:bg-blue-500 text-white'
+                : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+            }`}
+            onClick={() => canGenerate && generateFull(generationMode)}
+            disabled={!canGenerate}
+            title={generateDisabledReason ?? 'Generate optimized layouts'}
+          >
+            Generate
+          </button>
+        </div>
+      )}
+
+      {/* Compare */}
+      <button
+        className={`px-2 py-1 text-[11px] rounded transition-colors ${
+          compareCount >= 2
+            ? 'bg-purple-600 hover:bg-purple-500 text-white'
+            : 'bg-gray-800 text-gray-600 cursor-not-allowed'
+        }`}
+        onClick={onCompare}
+        disabled={compareCount < 2}
+        title={compareCount >= 2 ? `Compare ${compareCount} selected layouts` : 'Select 2+ candidates to compare'}
+      >
+        Compare{compareCount >= 2 ? ` (${compareCount})` : ''}
+      </button>
+
+      <div className="w-px h-5 bg-gray-800" />
+
+      {/* Pattern Composer toggle */}
+      <button
+        className={`px-2 py-1 text-[11px] rounded transition-colors ${
+          composerOpen
+            ? 'bg-gray-700 text-gray-200'
+            : 'bg-gray-800 text-gray-400 hover:text-gray-300 hover:bg-gray-700'
+        }`}
+        onClick={onToggleComposer}
+        title="Toggle Pattern Composer"
+      >
+        Composer
+      </button>
+
+      {/* Settings gear */}
+      <SettingsGear
+        gridLabels={viewSettings.gridLabels}
+        layoutDisplay={viewSettings.layoutDisplay}
+        onToggleGridLabel={toggleGridLabel}
+        onToggleLayoutDisplay={toggleLayoutDisplay}
+        onDuplicateLayout={() => {
+          if (state.workingLayout) {
+            dispatch({ type: 'SAVE_AS_VARIANT', payload: { name: `${state.workingLayout.name} copy`, source: 'working' } });
+          } else {
+            dispatch({ type: 'CREATE_WORKING_LAYOUT' });
+            dispatch({ type: 'SAVE_AS_VARIANT', payload: { name: `${state.activeLayout.name} copy`, source: 'working' } });
+            dispatch({ type: 'DISCARD_WORKING_LAYOUT' });
+          }
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Restructures the PushFlow workspace around three focal points for better visual hierarchy and workflow clarity:
	1.	Push Grid — large, dominant center column
	2.	Event Timeline — directly below the grid (moved from bottom drawer), tightly coupled spatially
	3.	Layout Options — right column with candidate mini grid previews and multi-select comparison
What changed
New: WorkspaceToolbar — Unified top bar that merges the old header block and EditorToolbar into a single concise row. Contains: library navigation, editable project name, BPM, layout status badge, workflow actions (Promote/Save Variant/Discard), undo/redo, save/export, optimizer selector, generate button, global “Compare Selected” trigger, settings gear, and stale indicator. Eliminates the duplicated project name that previously appeared in both the header and toolbar.
New: ActiveLayoutSummary — Top section of the right column. Shows layout identity (name, role badge, feasibility), score overview (QuickStats), cost breakdown bars, event difficulty chart, contextual event/transition detail (moved from center column), unplayable diagnostics, and cost toggles. Absorbs the “understand current layout” responsibilities from the old monolithic PerformanceAnalysisPanel.
New: LayoutOptionsPanel — Bottom section of the right column. Displays candidate cards in a scrollable grid with multi-select checkboxes for comparison, saved variants list, and optimization move trace. Each card shows a mini grid preview, tradeoff profile, and Promote/Load actions.
New: CompareModal — Full-screen overlay for side-by-side candidate comparison (replaces inline compare mode). Triggered by selecting 2+ candidates via checkboxes and clicking “Compare Selected” in the toolbar.
Modified: CandidatePreviewCard — Added compare checkbox (top-left), removed per-card “Compare” button, added “Load” button. Mini grid preview cell size increased from 14px to 18px.
Restructured: PerformanceWorkspace — Complete layout overhaul:
	∙	Full-viewport h-screen layout instead of unbounded scroll
	∙	Timeline moved from bottom drawer tab into center column
	∙	Right column always visible (was collapsed by default)
	∙	EventDetailPanel and TransitionDetailPanel content absorbed into ActiveLayoutSummary
	∙	Bottom drawer simplified to Pattern Composer only (collapsible)
	∙	Compare mode now uses modal overlay instead of inline grid swap
Layout structure
┌──────────────────────────────────────────────────────────────┐
│  WorkspaceToolbar (single row)                               │
├─────────┬──────────────────────────────┬─────────────────────┤
│ Left    │ Center Column                │ Right Column        │
│ Panel   │                              │                     │
│         │ ┌──────────────────────────┐ │ ActiveLayout        │
│ Sounds  │ │   InteractiveGrid        │ │ Summary             │
│ ──or──  │ │   (dominant, flex-1)     │ │                     │
│ Events  │ └──────────────────────────┘ │ ─────────────────   │
│ (tabs)  │ ┌──────────────────────────┐ │ LayoutOptions       │
│         │ │   UnifiedTimeline        │ │ Panel               │
│         │ │   (fixed ~200px)         │ │ (scrollable)        │
│         │ └──────────────────────────┘ │                     │
├─────────┴──────────────────────────────┴─────────────────────┤
│  Pattern Composer (collapsible bottom drawer)                │
└──────────────────────────────────────────────────────────────┘

Design decisions
	∙	Global compare over per-card compare: Aligns with the canonical workflow contract that “Compare is read-only and should be a deliberate action.” Multi-select + toolbar button makes comparison intentional.
	∙	Timeline in center column: Spatially couples the timeline with the grid it visualizes. Previously buried in a bottom drawer tab.
	∙	Right column always visible: Analysis and candidates immediately available after generation.
	∙	Modal for compare: Keeps main workspace layout stable. Compare is a focused read-only task.
	∙	Event/transition detail in right panel: Frees center column vertical space for the grid.