### PR TITLE
Refactor right panel into tabbed Costs/Layouts interface

### DIFF
--- a/src/ui/components/panels/ActiveLayoutSummary.tsx
+++ b/src/ui/components/panels/ActiveLayoutSummary.tsx
@@ -117,7 +117,7 @@ export function ActiveLayoutSummary() {
 
   return (
     <>
-      <div className="rounded-lg glass-panel flex flex-col overflow-hidden" style={{ maxHeight: '50vh' }}>
+      <div className="flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800 flex-shrink-0">
           <div className="flex items-center gap-2">

--- a/src/ui/components/panels/LayoutOptionsPanel.tsx
+++ b/src/ui/components/panels/LayoutOptionsPanel.tsx
@@ -28,7 +28,7 @@ export function LayoutOptionsPanel({
   const compareCount = selectedForCompare.size;
 
   return (
-    <div className="rounded-lg glass-panel flex flex-col overflow-hidden flex-1 min-h-0">
+    <div className="flex flex-col overflow-hidden flex-1 min-h-0">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-gray-800 flex-shrink-0">
         <div className="flex items-center gap-2">

--- a/src/ui/components/workspace/PerformanceWorkspace.tsx
+++ b/src/ui/components/workspace/PerformanceWorkspace.tsx
@@ -9,7 +9,7 @@
  * Layout: full-viewport 3-column with unified top toolbar.
  * - Left: tabbed Sounds/Events panel
  * - Center: Grid + Timeline stacked
- * - Right: ActiveLayoutSummary + LayoutOptionsPanel
+ * - Right: tabbed Costs/Layouts panel (mirrors left panel structure)
  * - Bottom drawer: Pattern Composer (collapsible)
  */
 
@@ -33,6 +33,7 @@ import { CompareModal } from '../panels/CompareModal';
 import { MoveTracePanel } from '../panels/MoveTracePanel';
 
 type LeftPanelTab = 'sounds' | 'events';
+type RightPanelTab = 'costs' | 'layouts';
 type TimelineTab = 'timeline' | 'composer';
 
 // Panel width constraints
@@ -61,6 +62,7 @@ function PerformanceWorkspaceInner() {
 
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [leftTab, setLeftTab] = useState<LeftPanelTab>('sounds');
+  const [rightTab, setRightTab] = useState<RightPanelTab>('costs');
   const [onionSkin, setOnionSkin] = useState(false);
   const [timelineTab, setTimelineTab] = useState<TimelineTab>('timeline');
 
@@ -316,21 +318,53 @@ function PerformanceWorkspaceInner() {
           <div className="w-px h-8 bg-gray-700 group-hover:bg-blue-400 transition-colors" />
         </div>
 
-        {/* Right Column: Summary + Options + Cost Evaluation + Trace */}
-        <div className="flex-shrink-0 flex flex-col gap-3 min-h-0 overflow-y-auto" style={{ width: rightWidth }}>
-          <ActiveLayoutSummary />
-          <LayoutOptionsPanel
-            selectedForCompare={selectedForCompare}
-            onToggleCompare={handleToggleCompare}
-            onCompare={handleOpenCompare}
-          />
-
-          {/* Move Trace section */}
-          {state.moveHistory && state.moveHistory.length > 0 && (
-            <div className="rounded-lg glass-panel p-3">
-              <MoveTracePanel moves={state.moveHistory} />
+        {/* Right Column: Tabbed Costs / Layouts */}
+        <div className="flex-shrink-0 flex flex-col min-h-0" style={{ width: rightWidth }}>
+          <div className="rounded-lg glass-panel flex flex-col flex-1 min-h-0">
+            {/* Tab header */}
+            <div className="flex items-center border-b border-gray-800 flex-shrink-0">
+              <button
+                className={`flex-1 px-3 py-2 text-[11px] font-medium transition-colors ${
+                  rightTab === 'costs'
+                    ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
+                    : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+                }`}
+                onClick={() => setRightTab('costs')}
+              >
+                Costs
+              </button>
+              <button
+                className={`flex-1 px-3 py-2 text-[11px] font-medium transition-colors ${
+                  rightTab === 'layouts'
+                    ? 'text-gray-200 bg-gray-800/50 border-b-2 border-blue-500'
+                    : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+                }`}
+                onClick={() => setRightTab('layouts')}
+              >
+                Layouts
+              </button>
             </div>
-          )}
+
+            {/* Tab content */}
+            <div className="overflow-y-auto flex-1 min-h-0">
+              {rightTab === 'costs' ? (
+                <ActiveLayoutSummary />
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <LayoutOptionsPanel
+                    selectedForCompare={selectedForCompare}
+                    onToggleCompare={handleToggleCompare}
+                    onCompare={handleOpenCompare}
+                  />
+                  {state.moveHistory && state.moveHistory.length > 0 && (
+                    <div className="p-3">
+                      <MoveTracePanel moves={state.moveHistory} />
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Restructured the right panel of the PerformanceWorkspace to use a tabbed interface that mirrors the left panel's design pattern. The Costs tab displays the ActiveLayoutSummary, while the Layouts tab contains the LayoutOptionsPanel and MoveTracePanel.

## Key Changes
- Added `RightPanelTab` type to manage 'costs' and 'layouts' tabs
- Introduced `rightTab` state to track the active right panel tab
- Refactored right column layout from stacked components to a tabbed container with:
  - Tab header with "Costs" and "Layouts" buttons
  - Conditional content rendering based on active tab
  - Proper scrolling and flex layout for tab content
- Moved MoveTracePanel into the Layouts tab alongside LayoutOptionsPanel
- Removed hardcoded styling (glass-panel, rounded-lg, maxHeight) from child panels (ActiveLayoutSummary and LayoutOptionsPanel) to allow the parent tabbed container to manage layout
- Updated documentation comment to reflect new right panel structure

## Implementation Details
- Tab styling follows the existing design system with hover states and active indicators (blue bottom border)
- Content area uses `overflow-y-auto flex-1 min-h-0` for proper scrolling behavior within the tab container
- Child panels (ActiveLayoutSummary, LayoutOptionsPanel) now rely on parent container for styling, reducing duplication

https://claude.ai/code/session_01HgK8QnYazitZpUDN3GP9zc