### PR TITLE
Add Composer preset library with placement, mirroring, and validation

### DIFF
--- a/src/engine/mapping/presetTransform.ts
+++ b/src/engine/mapping/presetTransform.ts
@@ -1,0 +1,248 @@
+/**
+ * Preset Transform Functions.
+ *
+ * Handles relative↔absolute coordinate conversion, mirror transform,
+ * and placement validation for ComposerPresets.
+ */
+
+import { type PadCoord, isValidPad, padKey, GRID_ROWS, GRID_COLS } from '../../types/padGrid';
+import { type PresetPad, type PresetBoundingBox, type ComposerPreset } from '../../types/composerPreset';
+import { type HandSide } from '../../types/fingerModel';
+import { isZoneValid } from '../surface/handZone';
+
+// ============================================================================
+// Relative ↔ Absolute Conversion
+// ============================================================================
+
+/** Convert a relative preset pad position to absolute grid coordinates. */
+export function toAbsolute(
+  pad: PresetPad,
+  anchorRow: number,
+  anchorCol: number,
+): PadCoord {
+  return {
+    row: anchorRow + pad.position.rowOffset,
+    col: anchorCol + pad.position.colOffset,
+  };
+}
+
+/** Convert all preset pads to absolute grid coordinates. */
+export function allToAbsolute(
+  pads: PresetPad[],
+  anchorRow: number,
+  anchorCol: number,
+): PadCoord[] {
+  return pads.map(pad => toAbsolute(pad, anchorRow, anchorCol));
+}
+
+/** Convert absolute grid coordinates back to relative, given an anchor. */
+export function toRelative(
+  coord: PadCoord,
+  anchorRow: number,
+  anchorCol: number,
+): { rowOffset: number; colOffset: number } {
+  return {
+    rowOffset: coord.row - anchorRow,
+    colOffset: coord.col - anchorCol,
+  };
+}
+
+// ============================================================================
+// Placement Validation
+// ============================================================================
+
+export interface PlacementValidationResult {
+  valid: boolean;
+  reasons: string[];
+}
+
+/**
+ * Validate whether a preset can be placed at the given anchor position.
+ *
+ * Checks:
+ * 1. All pads are within the 8×8 grid bounds
+ * 2. All pads satisfy hand zone constraints
+ * 3. No pads collide with occupied positions (if provided)
+ */
+export function validatePlacement(
+  pads: PresetPad[],
+  anchorRow: number,
+  anchorCol: number,
+  occupiedPads?: Set<string>,
+): PlacementValidationResult {
+  const reasons: string[] = [];
+
+  for (const pad of pads) {
+    const abs = toAbsolute(pad, anchorRow, anchorCol);
+
+    // Grid bounds check
+    if (!isValidPad(abs)) {
+      reasons.push(
+        `Pad at (${abs.row}, ${abs.col}) is outside the 8×8 grid`
+      );
+    }
+
+    // Hand zone check (only if within grid)
+    if (isValidPad(abs) && !isZoneValid(abs, pad.hand)) {
+      reasons.push(
+        `Pad at (${abs.row}, ${abs.col}) is outside the ${pad.hand} hand zone`
+      );
+    }
+
+    // Collision check
+    if (occupiedPads && isValidPad(abs)) {
+      const key = padKey(abs.row, abs.col);
+      if (occupiedPads.has(key)) {
+        reasons.push(
+          `Pad at (${abs.row}, ${abs.col}) collides with an occupied position`
+        );
+      }
+    }
+  }
+
+  return {
+    valid: reasons.length === 0,
+    reasons,
+  };
+}
+
+/**
+ * Check if a placement is valid (quick boolean check).
+ */
+export function isPlacementValid(
+  pads: PresetPad[],
+  anchorRow: number,
+  anchorCol: number,
+  occupiedPads?: Set<string>,
+): boolean {
+  return validatePlacement(pads, anchorRow, anchorCol, occupiedPads).valid;
+}
+
+/**
+ * Get the set of pad keys that would be occupied by a placement.
+ */
+export function getPlacementPadKeys(
+  pads: PresetPad[],
+  anchorRow: number,
+  anchorCol: number,
+): string[] {
+  return pads
+    .map(pad => toAbsolute(pad, anchorRow, anchorCol))
+    .filter(isValidPad)
+    .map(coord => padKey(coord.row, coord.col));
+}
+
+// ============================================================================
+// Mirror Transform
+// ============================================================================
+
+/** Swap hand side. */
+function flipHand(hand: HandSide): HandSide {
+  return hand === 'left' ? 'right' : 'left';
+}
+
+/**
+ * Mirror a preset's pads horizontally.
+ *
+ * - Flips colOffset: `colOffset → (boundingBox.cols - 1 - colOffset)`
+ * - Swaps hand: left ↔ right
+ * - Keeps finger type unchanged (thumb stays thumb, etc.)
+ * - rowOffset is preserved (no vertical flip)
+ */
+export function mirrorPads(
+  pads: PresetPad[],
+  boundingBox: PresetBoundingBox,
+): PresetPad[] {
+  return pads.map(pad => ({
+    ...pad,
+    position: {
+      rowOffset: pad.position.rowOffset,
+      colOffset: boundingBox.cols - 1 - pad.position.colOffset,
+    },
+    hand: flipHand(pad.hand),
+  }));
+}
+
+/**
+ * Create a mirrored copy of a ComposerPreset.
+ *
+ * The original preset is unchanged.
+ * Handedness flips: left ↔ right, both stays both.
+ */
+export function mirrorPreset(preset: ComposerPreset): ComposerPreset {
+  const mirroredPads = mirrorPads(preset.pads, preset.boundingBox);
+  const mirroredHandedness = preset.handedness === 'left' ? 'right'
+    : preset.handedness === 'right' ? 'left'
+    : 'both';
+
+  return {
+    ...preset,
+    pads: mirroredPads,
+    handedness: mirroredHandedness,
+    // boundingBox dimensions don't change — just the pad positions within it
+  };
+}
+
+// ============================================================================
+// Anchor Calculation
+// ============================================================================
+
+/**
+ * Find all valid anchor positions for a preset on the grid.
+ * Useful for showing valid drop zones during drag.
+ */
+export function findValidAnchors(
+  pads: PresetPad[],
+  occupiedPads?: Set<string>,
+): PadCoord[] {
+  const valid: PadCoord[] = [];
+  for (let row = 0; row < GRID_ROWS; row++) {
+    for (let col = 0; col < GRID_COLS; col++) {
+      if (isPlacementValid(pads, row, col, occupiedPads)) {
+        valid.push({ row, col });
+      }
+    }
+  }
+  return valid;
+}
+
+/**
+ * Snap a cursor grid position to the nearest valid anchor.
+ * Returns null if no valid anchor exists.
+ */
+export function snapToNearestValidAnchor(
+  cursorRow: number,
+  cursorCol: number,
+  pads: PresetPad[],
+  occupiedPads?: Set<string>,
+): PadCoord | null {
+  // Try the cursor position first
+  if (isPlacementValid(pads, cursorRow, cursorCol, occupiedPads)) {
+    return { row: cursorRow, col: cursorCol };
+  }
+
+  // Search outward in expanding rings
+  for (let radius = 1; radius <= Math.max(GRID_ROWS, GRID_COLS); radius++) {
+    let best: PadCoord | null = null;
+    let bestDist = Infinity;
+
+    for (let dr = -radius; dr <= radius; dr++) {
+      for (let dc = -radius; dc <= radius; dc++) {
+        if (Math.abs(dr) !== radius && Math.abs(dc) !== radius) continue; // Only check ring edge
+        const r = cursorRow + dr;
+        const c = cursorCol + dc;
+        if (r < 0 || r >= GRID_ROWS || c < 0 || c >= GRID_COLS) continue;
+        if (isPlacementValid(pads, r, c, occupiedPads)) {
+          const dist = Math.sqrt(dr * dr + dc * dc);
+          if (dist < bestDist) {
+            bestDist = dist;
+            best = { row: r, col: c };
+          }
+        }
+      }
+    }
+    if (best) return best;
+  }
+
+  return null;
+}

--- a/src/types/composerPreset.ts
+++ b/src/types/composerPreset.ts
@@ -1,0 +1,215 @@
+/**
+ * Composer Preset Types.
+ *
+ * A ComposerPreset is the core artifact of the Composer reverse workflow.
+ * It bundles three things into one authored unit:
+ *   1. Relative pad layout
+ *   2. Explicit finger assignment (mandatory)
+ *   3. Quantized event pattern
+ *
+ * Presets are stored with relative coordinates so they can be placed
+ * at any valid position on the 8×8 Push grid via translation.
+ */
+
+import { type FingerType, type HandSide } from './fingerModel';
+import { type LoopConfig, type LoopLane, type LoopEvent, type LoopCellKey } from './loopEditor';
+
+// ============================================================================
+// Relative Coordinate System
+// ============================================================================
+
+/** A pad position relative to the preset's bounding box origin (0,0 = bottom-left). */
+export interface RelativePadPosition {
+  /** Row offset from bottom of bounding box (0 = lowest row). */
+  rowOffset: number;
+  /** Column offset from left of bounding box (0 = leftmost col). */
+  colOffset: number;
+}
+
+// ============================================================================
+// Preset Pad
+// ============================================================================
+
+/** A single pad in a preset with its voice slot and finger assignment. */
+export interface PresetPad {
+  /** Relative position within the preset's bounding box. */
+  position: RelativePadPosition;
+  /** Lane ID this pad is linked to (connects pad → events). */
+  laneId: string;
+  /** Mandatory finger assignment. */
+  finger: FingerType;
+  /** Which hand plays this pad. */
+  hand: HandSide;
+}
+
+// ============================================================================
+// Handedness
+// ============================================================================
+
+/** Handedness classification for mirror eligibility. */
+export type PresetHandedness = 'left' | 'right' | 'both';
+
+// ============================================================================
+// Bounding Box
+// ============================================================================
+
+/** Size of the preset's relative grid. */
+export interface PresetBoundingBox {
+  /** Number of rows spanned (max rowOffset + 1). */
+  rows: number;
+  /** Number of columns spanned (max colOffset + 1). */
+  cols: number;
+}
+
+// ============================================================================
+// Composer Preset
+// ============================================================================
+
+/**
+ * The core authored artifact: layout + fingers + events as one unit.
+ *
+ * This is NOT a PerformancePreset (which stores loop state without layout/finger data).
+ * A ComposerPreset is a fundamentally different concept: a reusable performance object
+ * that can be placed and combined in the workspace.
+ */
+export interface ComposerPreset {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt: number;
+
+  /** Relative pad layout with finger assignments (mandatory). */
+  pads: PresetPad[];
+
+  /** Event pattern data. */
+  config: LoopConfig;
+  lanes: LoopLane[];
+  /** Serialized as [key, event][] for JSON compatibility. */
+  events: [LoopCellKey, LoopEvent][];
+
+  /** Derived metadata (computed on save, used for filtering/preview). */
+  handedness: PresetHandedness;
+  mirrorEligible: boolean;
+  boundingBox: PresetBoundingBox;
+
+  /** User-facing metadata. */
+  tags: string[];
+  category?: string;
+}
+
+// ============================================================================
+// Placed Preset Instance
+// ============================================================================
+
+/**
+ * A placed instance of a preset in the workspace.
+ *
+ * Contains a snapshot of preset data at placement time so the instance
+ * is self-contained and survives preset edits/deletion.
+ */
+export interface PlacedPresetInstance {
+  id: string;
+  /** Reference to source preset (for UI linking, may be stale). */
+  presetId: string;
+  /** Snapshot of name at placement time. */
+  presetName: string;
+
+  /** Absolute anchor position on the 8×8 grid (where bounding box origin maps). */
+  anchorRow: number;
+  anchorCol: number;
+
+  /** Whether this instance is mirrored relative to the original preset. */
+  isMirrored: boolean;
+
+  /** Snapshot of preset data (may be mirrored). */
+  pads: PresetPad[];
+  config: LoopConfig;
+  lanes: LoopLane[];
+  events: [LoopCellKey, LoopEvent][];
+  boundingBox: PresetBoundingBox;
+}
+
+// ============================================================================
+// Workspace Assembly State
+// ============================================================================
+
+/** Ephemeral drag preview state (not persisted). */
+export interface PresetDragPreview {
+  presetId: string;
+  anchorRow: number;
+  anchorCol: number;
+  isMirrored: boolean;
+  isValid: boolean;
+  pads: PresetPad[];
+  boundingBox: PresetBoundingBox;
+}
+
+/** State for the Composer workspace assembly. */
+export interface ComposerWorkspaceState {
+  placedInstances: PlacedPresetInstance[];
+  selectedInstanceId: string | null;
+}
+
+// ============================================================================
+// Pure Helpers
+// ============================================================================
+
+/** Compute bounding box from a set of preset pads. */
+export function computeBoundingBox(pads: PresetPad[]): PresetBoundingBox {
+  if (pads.length === 0) return { rows: 0, cols: 0 };
+  let maxRow = 0;
+  let maxCol = 0;
+  for (const pad of pads) {
+    if (pad.position.rowOffset > maxRow) maxRow = pad.position.rowOffset;
+    if (pad.position.colOffset > maxCol) maxCol = pad.position.colOffset;
+  }
+  return { rows: maxRow + 1, cols: maxCol + 1 };
+}
+
+/** Determine handedness from preset pads. */
+export function computeHandedness(pads: PresetPad[]): PresetHandedness {
+  if (pads.length === 0) return 'both';
+  let hasLeft = false;
+  let hasRight = false;
+  for (const pad of pads) {
+    if (pad.hand === 'left') hasLeft = true;
+    if (pad.hand === 'right') hasRight = true;
+    if (hasLeft && hasRight) return 'both';
+  }
+  return hasLeft ? 'left' : 'right';
+}
+
+/** Determine mirror eligibility (single-hand presets only). */
+export function isMirrorEligible(handedness: PresetHandedness): boolean {
+  return handedness === 'left' || handedness === 'right';
+}
+
+/**
+ * Normalize pad positions to be relative to bounding box origin.
+ * Shifts all positions so the minimum row/col offset is 0.
+ */
+export function normalizePadPositions(pads: PresetPad[]): PresetPad[] {
+  if (pads.length === 0) return [];
+  let minRow = Infinity;
+  let minCol = Infinity;
+  for (const pad of pads) {
+    if (pad.position.rowOffset < minRow) minRow = pad.position.rowOffset;
+    if (pad.position.colOffset < minCol) minCol = pad.position.colOffset;
+  }
+  if (minRow === 0 && minCol === 0) return pads;
+  return pads.map(pad => ({
+    ...pad,
+    position: {
+      rowOffset: pad.position.rowOffset - minRow,
+      colOffset: pad.position.colOffset - minCol,
+    },
+  }));
+}
+
+/** Create the initial empty composer workspace state. */
+export function createInitialComposerWorkspaceState(): ComposerWorkspaceState {
+  return {
+    placedInstances: [],
+    selectedInstanceId: null,
+  };
+}

--- a/src/ui/components/InteractiveGrid.tsx
+++ b/src/ui/components/InteractiveGrid.tsx
@@ -19,6 +19,7 @@ import { type FingerAssignment } from '../../types/executionPlan';
 import { type GridLabelSettings } from '../state/viewSettings';
 import { buildSelectedTransitionModel } from '../analysis/selectionModel';
 import { midiNoteToName } from '../../utils/midiNotes';
+import { COMPOSER_PRESET_DRAG_TYPE } from './composer/PresetCard';
 
 interface InteractiveGridProps {
   assignments?: FingerAssignment[];
@@ -33,6 +34,10 @@ interface InteractiveGridProps {
   voiceConstraints?: Record<string, { hand?: 'left' | 'right'; finger?: string }>;
   /** Grid label settings controlling what info is shown on pads. */
   gridLabels?: GridLabelSettings;
+  /** Pad keys belonging to the currently selected placed preset instance. */
+  highlightedInstancePads?: Set<string>;
+  /** Callback when a composer preset is dropped on the grid. */
+  onPresetDrop?: (presetId: string, anchorRow: number, anchorCol: number, isMirrored: boolean) => void;
 }
 
 /** Abbreviated finger names for display (numbered: thumb=1 through pinky=5) */
@@ -74,7 +79,7 @@ function safeColorAlpha(color: string | null | undefined, alpha: number, fallbac
 /** Physical reach threshold: pads farther apart than this are flagged as impossible. */
 const IMPOSSIBLE_REACH_THRESHOLD = 5;
 
-export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick, layoutOverride, onionSkin = false, voiceConstraints = {}, gridLabels }: InteractiveGridProps) {
+export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick, layoutOverride, onionSkin = false, voiceConstraints = {}, gridLabels, highlightedInstancePads, onPresetDrop }: InteractiveGridProps) {
   const { state, dispatch } = useProject();
   const layout = layoutOverride ?? getDisplayedLayout(state);
   const [dragOverPad, setDragOverPad] = useState<string | null>(null);
@@ -278,6 +283,19 @@ export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick,
     e.preventDefault();
     setDragOverPad(null);
 
+    // Check for composer preset drop first
+    const presetData = e.dataTransfer.getData(COMPOSER_PRESET_DRAG_TYPE);
+    if (presetData && onPresetDrop) {
+      try {
+        const { presetId, isMirrored } = JSON.parse(presetData);
+        const [rowStr, colStr] = padKey.split(',');
+        const anchorRow = parseInt(rowStr, 10);
+        const anchorCol = parseInt(colStr, 10);
+        onPresetDrop(presetId, anchorRow, anchorCol, isMirrored);
+      } catch { /* invalid data */ }
+      return;
+    }
+
     // Check pad-to-pad drag first (swap) — must come before stream check
     // because handlePadDragStart sets both data types
     const padData = e.dataTransfer.getData('application/pushflow-pad');
@@ -369,6 +387,7 @@ export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick,
       const isImpossible = impossibleMoveTargets.has(padKey);
       const isDragOver = padKey === dragOverPad;
       const isDragSource = padKey === dragSourcePad;
+      const isInstanceHighlighted = highlightedInstancePads?.has(padKey) ?? false;
       const constraint = layout?.fingerConstraints[padKey];
       const isLocked = !!layout?.placementLocks[padKey];
       const isGreyedOut = hasEventSelected && !isSelected;
@@ -444,6 +463,7 @@ export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick,
             ${isPrevious ? 'opacity-60' : ''}
             ${isShared ? 'ring-1 ring-emerald-400/50' : ''}
             ${isImpossible ? 'ring-2 ring-red-500/80' : ''}
+            ${isInstanceHighlighted ? 'ring-2 ring-violet-400/60' : ''}
             ${isDragOver ? 'ring-2 ring-blue-400/60 scale-105 bg-[var(--bg-card)]' : ''}
             ${isDragSource ? 'opacity-30' : ''}
             ${isMuted ? 'opacity-30 pointer-events-none' : ''}

--- a/src/ui/components/composer/PresetCard.tsx
+++ b/src/ui/components/composer/PresetCard.tsx
@@ -1,0 +1,258 @@
+/**
+ * PresetCard.
+ *
+ * Displays a single ComposerPreset in the library panel.
+ * Shows mini grid preview, timeline strip, hand indicator, and metadata.
+ * Supports drag initiation for workspace placement.
+ */
+
+import { useMemo, type DragEvent } from 'react';
+import { type ComposerPreset, type PresetPad } from '../../../types/composerPreset';
+import { GRID_ROWS, GRID_COLS } from '../../../types/padGrid';
+import { totalSteps } from '../../../types/loopEditor';
+
+/** Drag data type identifier for ComposerPreset drag-and-drop. */
+export const COMPOSER_PRESET_DRAG_TYPE = 'application/x-pushflow-composer-preset';
+
+interface PresetCardProps {
+  preset: ComposerPreset;
+  isSelected?: boolean;
+  isMirrored?: boolean;
+  onSelect?: (presetId: string) => void;
+  onDelete?: (presetId: string) => void;
+  onDuplicate?: (presetId: string) => void;
+  onRename?: (presetId: string) => void;
+  onToggleMirror?: (presetId: string) => void;
+}
+
+/** Hand indicator colors. */
+const HAND_COLORS = {
+  left: '#0088FF',
+  right: '#FF4400',
+  both: '#888888',
+} as const;
+
+const HAND_LABELS = {
+  left: 'L',
+  right: 'R',
+  both: 'L+R',
+} as const;
+
+export function PresetCard({
+  preset,
+  isSelected = false,
+  isMirrored = false,
+  onSelect,
+  onDelete,
+  onDuplicate,
+  onRename,
+  onToggleMirror,
+}: PresetCardProps) {
+  const handleDragStart = (e: DragEvent) => {
+    e.dataTransfer.setData(COMPOSER_PRESET_DRAG_TYPE, JSON.stringify({
+      presetId: preset.id,
+      isMirrored,
+    }));
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
+  return (
+    <div
+      className={`group relative px-3 py-2 rounded-lg border cursor-grab transition-colors ${
+        isSelected
+          ? 'bg-violet-900/30 border-violet-500/50'
+          : 'bg-gray-800/50 border-gray-700/50 hover:border-gray-600'
+      }`}
+      draggable
+      onDragStart={handleDragStart}
+      onClick={() => onSelect?.(preset.id)}
+    >
+      {/* Header: name + hand indicator */}
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className="text-xs font-medium text-gray-200 truncate flex-1">
+          {preset.name}
+        </span>
+        <span
+          className="text-[10px] font-mono px-1 rounded"
+          style={{
+            color: HAND_COLORS[preset.handedness],
+            backgroundColor: `${HAND_COLORS[preset.handedness]}15`,
+          }}
+        >
+          {HAND_LABELS[preset.handedness]}
+        </span>
+        {preset.mirrorEligible && (
+          <button
+            className={`text-[10px] px-1 rounded transition-colors ${
+              isMirrored
+                ? 'bg-violet-600/30 text-violet-300'
+                : 'bg-gray-700/50 text-gray-500 hover:text-gray-300'
+            }`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleMirror?.(preset.id);
+            }}
+            title="Mirror (flip hand)"
+          >
+            ⟷
+          </button>
+        )}
+      </div>
+
+      {/* Mini grid preview */}
+      <MiniGridPreview pads={preset.pads} boundingBox={preset.boundingBox} />
+
+      {/* Mini timeline strip */}
+      <MiniTimelineStrip
+        events={preset.events}
+        config={preset.config}
+        lanes={preset.lanes}
+      />
+
+      {/* Footer: metadata */}
+      <div className="flex items-center gap-2 mt-1.5">
+        <span className="text-[10px] text-gray-500">
+          {preset.pads.length} pads · {preset.events.length} events
+        </span>
+        <div className="flex-1" />
+        {/* Action buttons (visible on hover) */}
+        <div className="hidden group-hover:flex items-center gap-1">
+          {onDuplicate && (
+            <button
+              className="text-[10px] text-gray-500 hover:text-gray-300"
+              onClick={(e) => { e.stopPropagation(); onDuplicate(preset.id); }}
+              title="Duplicate"
+            >
+              dup
+            </button>
+          )}
+          {onRename && (
+            <button
+              className="text-[10px] text-gray-500 hover:text-gray-300"
+              onClick={(e) => { e.stopPropagation(); onRename(preset.id); }}
+              title="Rename"
+            >
+              ren
+            </button>
+          )}
+          {onDelete && (
+            <button
+              className="text-[10px] text-red-400/60 hover:text-red-400"
+              onClick={(e) => { e.stopPropagation(); onDelete(preset.id); }}
+              title="Delete"
+            >
+              del
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Mini Grid Preview
+// ============================================================================
+
+function MiniGridPreview({
+  pads,
+  boundingBox,
+}: {
+  pads: PresetPad[];
+  boundingBox: { rows: number; cols: number };
+}) {
+  const cellSize = 6;
+  const gap = 1;
+  const displayRows = Math.min(boundingBox.rows, GRID_ROWS);
+  const displayCols = Math.min(boundingBox.cols, GRID_COLS);
+  const width = displayCols * (cellSize + gap) - gap;
+  const height = displayRows * (cellSize + gap) - gap;
+
+  const padSet = useMemo(() => {
+    const map = new Map<string, PresetPad>();
+    for (const pad of pads) {
+      map.set(`${pad.position.rowOffset},${pad.position.colOffset}`, pad);
+    }
+    return map;
+  }, [pads]);
+
+  return (
+    <div className="flex justify-center mb-1">
+      <svg width={width} height={height} className="opacity-80">
+        {Array.from({ length: displayRows }, (_, r) =>
+          Array.from({ length: displayCols }, (_, c) => {
+            // Flip row so bottom-left = visual bottom-left
+            const visualRow = displayRows - 1 - r;
+            const pad = padSet.get(`${r},${c}`);
+            const x = c * (cellSize + gap);
+            const y = visualRow * (cellSize + gap);
+
+            return (
+              <rect
+                key={`${r},${c}`}
+                x={x}
+                y={y}
+                width={cellSize}
+                height={cellSize}
+                rx={1}
+                fill={pad ? (pad.hand === 'left' ? '#0088FF' : '#FF4400') : '#333'}
+                opacity={pad ? 0.8 : 0.15}
+              />
+            );
+          })
+        )}
+      </svg>
+    </div>
+  );
+}
+
+// ============================================================================
+// Mini Timeline Strip
+// ============================================================================
+
+function MiniTimelineStrip({
+  events,
+  config,
+  lanes,
+}: {
+  events: ComposerPreset['events'];
+  config: ComposerPreset['config'];
+  lanes: ComposerPreset['lanes'];
+}) {
+  const steps = totalSteps(config);
+  const stripWidth = 120;
+  const stripHeight = Math.max(8, lanes.length * 3);
+
+  const laneIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    lanes.forEach((lane, i) => map.set(lane.id, i));
+    return map;
+  }, [lanes]);
+
+  if (events.length === 0) return null;
+
+  return (
+    <div className="flex justify-center mb-1">
+      <svg width={stripWidth} height={stripHeight} className="opacity-60">
+        {events.map(([, event], i) => {
+          const laneIdx = laneIndexMap.get(event.laneId) ?? 0;
+          const x = (event.stepIndex / steps) * stripWidth;
+          const y = (laneIdx / Math.max(lanes.length, 1)) * stripHeight;
+          const lane = lanes.find(l => l.id === event.laneId);
+
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={Math.max(1, stripWidth / steps)}
+              height={Math.max(2, stripHeight / Math.max(lanes.length, 1) - 1)}
+              fill={lane?.color ?? '#888'}
+              rx={0.5}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/src/ui/components/composer/PresetInspector.tsx
+++ b/src/ui/components/composer/PresetInspector.tsx
@@ -1,0 +1,356 @@
+/**
+ * PresetInspector.
+ *
+ * Right-panel inspector for a selected ComposerPreset or placed preset instance.
+ * Shows:
+ * - Grid preview with finger assignments
+ * - Event pattern details
+ * - Diagnostic cost breakdown (framed as model debugging, not prescriptive)
+ */
+
+import { useMemo } from 'react';
+import { type ComposerPreset, type PresetPad, type PlacedPresetInstance } from '../../../types/composerPreset';
+import { type FingerType } from '../../../types/fingerModel';
+import { GRID_ROWS, GRID_COLS } from '../../../types/padGrid';
+import { totalSteps } from '../../../types/loopEditor';
+
+interface PresetInspectorProps {
+  /** The preset being inspected (from library selection or placed instance). */
+  preset: ComposerPreset | null;
+  /** The placed instance (if inspecting a placed instance). */
+  instance?: PlacedPresetInstance | null;
+  /** Callback to remove a placed instance. */
+  onRemoveInstance?: (instanceId: string) => void;
+}
+
+const FINGER_LABELS: Record<FingerType, string> = {
+  thumb: 'Thumb',
+  index: 'Index',
+  middle: 'Middle',
+  ring: 'Ring',
+  pinky: 'Pinky',
+};
+
+const FINGER_ABBREV: Record<FingerType, string> = {
+  thumb: '1',
+  index: '2',
+  middle: '3',
+  ring: '4',
+  pinky: '5',
+};
+
+const HAND_COLORS = {
+  left: '#0088FF',
+  right: '#FF4400',
+} as const;
+
+export function PresetInspector({ preset, instance, onRemoveInstance }: PresetInspectorProps) {
+  if (!preset) return null;
+
+  const pads = instance?.pads ?? preset.pads;
+  const config = instance?.config ?? preset.config;
+  const lanes = instance?.lanes ?? preset.lanes;
+  const events = instance?.events ?? preset.events;
+  const steps = totalSteps(config);
+
+  return (
+    <div className="p-3 space-y-3">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold text-gray-200 truncate flex-1">
+          {instance ? instance.presetName : preset.name}
+        </span>
+        {instance && (
+          <span className="text-[10px] text-violet-400 bg-violet-500/10 px-1.5 py-0.5 rounded">
+            Placed
+          </span>
+        )}
+      </div>
+
+      {/* Grid Preview (larger) */}
+      <div className="bg-gray-800/30 rounded-lg p-2">
+        <div className="text-[10px] text-gray-500 mb-1.5">Pad Layout + Finger Assignment</div>
+        <InspectorGridPreview
+          pads={pads}
+          boundingBox={instance?.boundingBox ?? preset.boundingBox}
+          anchorRow={instance?.anchorRow}
+          anchorCol={instance?.anchorCol}
+        />
+      </div>
+
+      {/* Finger Assignment Table */}
+      <div className="bg-gray-800/30 rounded-lg p-2">
+        <div className="text-[10px] text-gray-500 mb-1.5">Finger Assignments</div>
+        <div className="space-y-0.5">
+          {pads.map((pad, i) => {
+            const lane = lanes.find(l => l.id === pad.laneId);
+            return (
+              <div key={i} className="flex items-center gap-2 text-[10px]">
+                <span
+                  className="w-2 h-2 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: lane?.color ?? '#888' }}
+                />
+                <span className="text-gray-400 truncate flex-1">
+                  {lane?.name ?? pad.laneId}
+                </span>
+                <span style={{ color: HAND_COLORS[pad.hand] }}>
+                  {pad.hand === 'left' ? 'L' : 'R'}{FINGER_ABBREV[pad.finger]}
+                </span>
+                <span className="text-gray-600">
+                  {FINGER_LABELS[pad.finger]}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Event Summary */}
+      <div className="bg-gray-800/30 rounded-lg p-2">
+        <div className="text-[10px] text-gray-500 mb-1.5">Event Pattern</div>
+        <div className="flex items-center gap-3 text-[10px] text-gray-400">
+          <span>{events.length} events</span>
+          <span>{config.barCount} bars</span>
+          <span>{config.subdivision} grid</span>
+          <span>{config.bpm} BPM</span>
+        </div>
+        {/* Mini timeline */}
+        <InspectorTimeline events={events} steps={steps} lanes={lanes} />
+      </div>
+
+      {/* Diagnostic Metrics */}
+      <div className="bg-gray-800/30 rounded-lg p-2">
+        <div className="text-[10px] text-gray-500 mb-1">Metric Breakdown</div>
+        <div className="text-[10px] text-gray-600 mb-2 italic">
+          These metrics help validate the playability model. If a natural pattern scores
+          poorly, the model may need recalibration.
+        </div>
+        <DiagnosticMetrics pads={pads} />
+      </div>
+
+      {/* Instance actions */}
+      {instance && onRemoveInstance && (
+        <button
+          className="w-full px-3 py-1.5 text-xs rounded bg-red-500/10 text-red-400 border border-red-500/20 hover:bg-red-500/20 transition-colors"
+          onClick={() => onRemoveInstance(instance.id)}
+        >
+          Remove from workspace
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Inspector Grid Preview (larger than card preview)
+// ============================================================================
+
+function InspectorGridPreview({
+  pads,
+  boundingBox,
+  anchorRow,
+  anchorCol,
+}: {
+  pads: PresetPad[];
+  boundingBox: { rows: number; cols: number };
+  anchorRow?: number;
+  anchorCol?: number;
+}) {
+  const cellSize = 12;
+  const gap = 2;
+  const showFullGrid = anchorRow !== undefined && anchorCol !== undefined;
+  const displayRows = showFullGrid ? GRID_ROWS : Math.min(boundingBox.rows, GRID_ROWS);
+  const displayCols = showFullGrid ? GRID_COLS : Math.min(boundingBox.cols, GRID_COLS);
+  const width = displayCols * (cellSize + gap) - gap;
+  const height = displayRows * (cellSize + gap) - gap;
+
+  const padMap = useMemo(() => {
+    const map = new Map<string, PresetPad>();
+    for (const pad of pads) {
+      const r = showFullGrid
+        ? (anchorRow ?? 0) + pad.position.rowOffset
+        : pad.position.rowOffset;
+      const c = showFullGrid
+        ? (anchorCol ?? 0) + pad.position.colOffset
+        : pad.position.colOffset;
+      map.set(`${r},${c}`, pad);
+    }
+    return map;
+  }, [pads, showFullGrid, anchorRow, anchorCol]);
+
+  return (
+    <div className="flex justify-center">
+      <svg width={width} height={height}>
+        {Array.from({ length: displayRows }, (_, r) =>
+          Array.from({ length: displayCols }, (_, c) => {
+            const visualRow = displayRows - 1 - r;
+            const pad = padMap.get(`${r},${c}`);
+            const x = c * (cellSize + gap);
+            const y = visualRow * (cellSize + gap);
+
+            return (
+              <g key={`${r},${c}`}>
+                <rect
+                  x={x}
+                  y={y}
+                  width={cellSize}
+                  height={cellSize}
+                  rx={2}
+                  fill={pad ? (pad.hand === 'left' ? '#0088FF' : '#FF4400') : '#222'}
+                  opacity={pad ? 0.7 : 0.1}
+                />
+                {pad && (
+                  <text
+                    x={x + cellSize / 2}
+                    y={y + cellSize / 2 + 1}
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize={7}
+                    fill="white"
+                    opacity={0.9}
+                  >
+                    {FINGER_ABBREV[pad.finger]}
+                  </text>
+                )}
+              </g>
+            );
+          })
+        )}
+      </svg>
+    </div>
+  );
+}
+
+// ============================================================================
+// Inspector Timeline
+// ============================================================================
+
+function InspectorTimeline({
+  events,
+  steps,
+  lanes,
+}: {
+  events: ComposerPreset['events'];
+  steps: number;
+  lanes: ComposerPreset['lanes'];
+}) {
+  const width = 200;
+  const laneHeight = 4;
+  const height = Math.max(12, lanes.length * (laneHeight + 1));
+
+  const laneIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    lanes.forEach((lane, i) => map.set(lane.id, i));
+    return map;
+  }, [lanes]);
+
+  if (events.length === 0) return null;
+
+  return (
+    <div className="flex justify-center mt-1.5">
+      <svg width={width} height={height} className="opacity-70">
+        {events.map(([, event], i) => {
+          const laneIdx = laneIndexMap.get(event.laneId) ?? 0;
+          const x = (event.stepIndex / steps) * width;
+          const y = laneIdx * (laneHeight + 1);
+          const lane = lanes.find(l => l.id === event.laneId);
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={Math.max(1, width / steps - 0.5)}
+              height={laneHeight}
+              fill={lane?.color ?? '#888'}
+              rx={0.5}
+            />
+          );
+        })}
+      </svg>
+    </div>
+  );
+}
+
+// ============================================================================
+// Diagnostic Metrics (model debugging framing)
+// ============================================================================
+
+function DiagnosticMetrics({ pads }: { pads: PresetPad[] }) {
+  // Compute simple spatial metrics from pad positions
+  const metrics = useMemo(() => {
+    if (pads.length === 0) return null;
+
+    // Hand balance
+    const leftCount = pads.filter(p => p.hand === 'left').length;
+    const rightCount = pads.filter(p => p.hand === 'right').length;
+    const total = pads.length;
+    const balance = total > 0 ? leftCount / total : 0.5;
+
+    // Compactness (average pairwise distance)
+    let totalDist = 0;
+    let pairCount = 0;
+    for (let i = 0; i < pads.length; i++) {
+      for (let j = i + 1; j < pads.length; j++) {
+        const dr = pads[i].position.rowOffset - pads[j].position.rowOffset;
+        const dc = pads[i].position.colOffset - pads[j].position.colOffset;
+        totalDist += Math.sqrt(dr * dr + dc * dc);
+        pairCount++;
+      }
+    }
+    const avgDist = pairCount > 0 ? totalDist / pairCount : 0;
+
+    // Finger variety
+    const fingers = new Set(pads.map(p => p.finger));
+
+    return {
+      handBalance: balance,
+      leftCount,
+      rightCount,
+      avgPairwiseDistance: avgDist,
+      fingerVariety: fingers.size,
+      totalPads: total,
+    };
+  }, [pads]);
+
+  if (!metrics) return <div className="text-[10px] text-gray-600">No pad data</div>;
+
+  const items = [
+    {
+      label: 'Hand Balance',
+      value: `${metrics.leftCount}L / ${metrics.rightCount}R`,
+      bar: metrics.handBalance,
+      description: 'Distribution of pads between hands',
+    },
+    {
+      label: 'Compactness',
+      value: `${metrics.avgPairwiseDistance.toFixed(1)} avg dist`,
+      bar: Math.min(1, 1 - metrics.avgPairwiseDistance / 8),
+      description: 'How close pads are to each other (lower distance = more compact)',
+    },
+    {
+      label: 'Finger Variety',
+      value: `${metrics.fingerVariety} / 5 fingers`,
+      bar: metrics.fingerVariety / 5,
+      description: 'Number of distinct fingers used',
+    },
+  ];
+
+  return (
+    <div className="space-y-2">
+      {items.map(item => (
+        <div key={item.label}>
+          <div className="flex items-center justify-between mb-0.5">
+            <span className="text-[10px] text-gray-400">{item.label}</span>
+            <span className="text-[10px] text-gray-500">{item.value}</span>
+          </div>
+          <div className="h-1 bg-gray-700 rounded-full overflow-hidden" title={item.description}>
+            <div
+              className="h-full rounded-full bg-gray-500 transition-all"
+              style={{ width: `${Math.max(5, item.bar * 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/components/composer/PresetLibraryPanel.tsx
+++ b/src/ui/components/composer/PresetLibraryPanel.tsx
@@ -1,0 +1,188 @@
+/**
+ * PresetLibraryPanel.
+ *
+ * Browsable library of ComposerPresets.
+ * Appears in the left panel "Presets" tab.
+ * Supports search, CRUD, and drag-to-workspace.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+import { type ComposerPreset, type PlacedPresetInstance } from '../../../types/composerPreset';
+import {
+  loadComposerPresets,
+  deleteComposerPreset,
+  duplicateComposerPreset,
+  renameComposerPreset,
+} from '../../persistence/composerPresetStorage';
+import { PresetCard } from './PresetCard';
+
+interface PresetLibraryPanelProps {
+  selectedPresetId?: string | null;
+  onSelectPreset?: (presetId: string | null) => void;
+  /** Set of preset IDs currently toggled to mirrored state. */
+  mirroredPresets?: Set<string>;
+  onToggleMirror?: (presetId: string) => void;
+  /** Currently placed instances in the workspace. */
+  placedInstances?: PlacedPresetInstance[];
+  /** Currently selected placed instance ID. */
+  selectedInstanceId?: string | null;
+  /** Callback to select a placed instance. */
+  onSelectInstance?: (instanceId: string | null) => void;
+}
+
+export function PresetLibraryPanel({
+  selectedPresetId,
+  onSelectPreset,
+  mirroredPresets,
+  onToggleMirror,
+  placedInstances = [],
+  selectedInstanceId,
+  onSelectInstance,
+}: PresetLibraryPanelProps) {
+  const [presets, setPresets] = useState<ComposerPreset[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  // Load presets from localStorage
+  useEffect(() => {
+    setPresets(loadComposerPresets());
+  }, [refreshKey]);
+
+  // Listen for storage events (other tabs) and custom refresh events
+  useEffect(() => {
+    const handleStorage = () => setRefreshKey(k => k + 1);
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener('composer-presets-changed', handleStorage);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('composer-presets-changed', handleStorage);
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    setRefreshKey(k => k + 1);
+    window.dispatchEvent(new Event('composer-presets-changed'));
+  }, []);
+
+  const handleDelete = useCallback((presetId: string) => {
+    if (!window.confirm('Delete this preset?')) return;
+    deleteComposerPreset(presetId);
+    if (selectedPresetId === presetId) {
+      onSelectPreset?.(null);
+    }
+    refresh();
+  }, [selectedPresetId, onSelectPreset, refresh]);
+
+  const handleDuplicate = useCallback((presetId: string) => {
+    duplicateComposerPreset(presetId);
+    refresh();
+  }, [refresh]);
+
+  const handleRename = useCallback((presetId: string) => {
+    const preset = presets.find(p => p.id === presetId);
+    if (!preset) return;
+    const newName = window.prompt('Rename preset:', preset.name);
+    if (!newName || newName === preset.name) return;
+    renameComposerPreset(presetId, newName);
+    refresh();
+  }, [presets, refresh]);
+
+  const handleSelect = useCallback((presetId: string) => {
+    onSelectPreset?.(selectedPresetId === presetId ? null : presetId);
+  }, [selectedPresetId, onSelectPreset]);
+
+  // Filter by search query
+  const filteredPresets = searchQuery.trim()
+    ? presets.filter(p =>
+        p.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        p.tags.some(t => t.toLowerCase().includes(searchQuery.toLowerCase()))
+      )
+    : presets;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-3 py-2 border-b border-gray-700/50">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs font-semibold text-gray-300">Composer Presets</span>
+          <span className="text-[10px] text-gray-500">{presets.length}</span>
+        </div>
+        <input
+          type="text"
+          placeholder="Search presets..."
+          value={searchQuery}
+          onChange={e => setSearchQuery(e.target.value)}
+          className="w-full px-2 py-1 text-xs bg-gray-800 border border-gray-700 rounded text-gray-300 placeholder-gray-600"
+        />
+      </div>
+
+      {/* Preset list */}
+      <div className="flex-1 overflow-y-auto px-2 py-2 space-y-2">
+        {filteredPresets.length === 0 ? (
+          <div className="text-center py-8">
+            <div className="text-xs text-gray-500 mb-1">
+              {searchQuery ? 'No matching presets' : 'No presets yet'}
+            </div>
+            <div className="text-[10px] text-gray-600">
+              {searchQuery
+                ? 'Try a different search'
+                : 'Use "Save Preset" in the Composer to create one'}
+            </div>
+          </div>
+        ) : (
+          filteredPresets.map(preset => (
+            <PresetCard
+              key={preset.id}
+              preset={preset}
+              isSelected={selectedPresetId === preset.id}
+              isMirrored={mirroredPresets?.has(preset.id) ?? false}
+              onSelect={handleSelect}
+              onDelete={handleDelete}
+              onDuplicate={handleDuplicate}
+              onRename={handleRename}
+              onToggleMirror={onToggleMirror}
+            />
+          ))
+        )}
+      </div>
+
+      {/* Placed Instances Section */}
+      {placedInstances.length > 0 && (
+        <div className="border-t border-gray-700/50 px-3 py-2">
+          <div className="text-[10px] text-gray-500 font-medium mb-1.5">
+            Placed ({placedInstances.length})
+          </div>
+          <div className="space-y-1">
+            {placedInstances.map(inst => (
+              <button
+                key={inst.id}
+                className={`w-full text-left px-2 py-1 rounded text-[10px] transition-colors ${
+                  selectedInstanceId === inst.id
+                    ? 'bg-violet-900/30 text-violet-300 border border-violet-500/30'
+                    : 'bg-gray-800/30 text-gray-400 border border-transparent hover:border-gray-700'
+                }`}
+                onClick={() => {
+                  onSelectInstance?.(selectedInstanceId === inst.id ? null : inst.id);
+                  onSelectPreset?.(null);
+                }}
+              >
+                <span className="truncate">{inst.presetName}</span>
+                <span className="text-gray-600 ml-1">
+                  ({inst.anchorRow},{inst.anchorCol})
+                  {inst.isMirrored && ' mirrored'}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Footer hint */}
+      <div className="px-3 py-1.5 border-t border-gray-700/30">
+        <div className="text-[10px] text-gray-600">
+          Drag a preset onto the grid to place it
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/components/panels/PerformanceAnalysisPanel.tsx
+++ b/src/ui/components/panels/PerformanceAnalysisPanel.tsx
@@ -654,6 +654,7 @@ function ViewAllModal({ candidates, savedVariants, soundStreams, selectedId, onS
                     onSelect={() => onSelect(c.id)}
                     onPromote={() => {}}
                     onToggleCompare={() => {}}
+                    onDelete={() => {}}
                   />
                 ))}
               </div>

--- a/src/ui/components/workspace/PerformanceWorkspace.tsx
+++ b/src/ui/components/workspace/PerformanceWorkspace.tsx
@@ -13,7 +13,7 @@
  * - Bottom drawer: Pattern Composer (collapsible)
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useReducer, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useProject } from '../../state/ProjectContext';
 import { useAutoAnalysis } from '../../hooks/useAutoAnalysis';
@@ -31,8 +31,24 @@ import { ActiveLayoutSummary } from '../panels/ActiveLayoutSummary';
 import { LayoutOptionsPanel } from '../panels/LayoutOptionsPanel';
 import { CompareModal } from '../panels/CompareModal';
 import { MoveTracePanel } from '../panels/MoveTracePanel';
+import { PresetLibraryPanel } from '../composer/PresetLibraryPanel';
+import { PresetInspector } from '../composer/PresetInspector';
+import { loadComposerPresets } from '../../persistence/composerPresetStorage';
+import {
+  type PlacedPresetInstance,
+  createInitialComposerWorkspaceState,
+} from '../../../types/composerPreset';
+import {
+  composerWorkspaceReducer,
+} from '../../state/composerWorkspaceReducer';
+import {
+  mirrorPreset,
+  validatePlacement,
+} from '../../../engine/mapping/presetTransform';
+import { generateId } from '../../../utils/idGenerator';
+import { padKey } from '../../../types/padGrid';
 
-type LeftPanelTab = 'sounds' | 'events';
+type LeftPanelTab = 'sounds' | 'events' | 'presets';
 type RightPanelTab = 'costs' | 'layouts';
 type TimelineTab = 'timeline' | 'composer';
 
@@ -65,6 +81,124 @@ function PerformanceWorkspaceInner() {
   const [rightTab, setRightTab] = useState<RightPanelTab>('costs');
   const [onionSkin, setOnionSkin] = useState(false);
   const [timelineTab, setTimelineTab] = useState<TimelineTab>('timeline');
+
+  // Composer preset library state
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const [mirroredPresets, setMirroredPresets] = useState<Set<string>>(new Set());
+  const handleToggleMirror = useCallback((presetId: string) => {
+    setMirroredPresets(prev => {
+      const next = new Set(prev);
+      if (next.has(presetId)) next.delete(presetId);
+      else next.add(presetId);
+      return next;
+    });
+  }, []);
+
+  // Composer workspace assembly state
+  const [composerWorkspace, composerDispatch] = useReducer(
+    composerWorkspaceReducer,
+    undefined,
+    createInitialComposerWorkspaceState,
+  );
+
+  // Compute highlighted pads for selected instance
+  const highlightedInstancePads = useMemo(() => {
+    if (!composerWorkspace.selectedInstanceId) return undefined;
+    const instance = composerWorkspace.placedInstances.find(
+      i => i.id === composerWorkspace.selectedInstanceId
+    );
+    if (!instance) return undefined;
+    const keys = new Set<string>();
+    for (const pad of instance.pads) {
+      keys.add(padKey(
+        instance.anchorRow + pad.position.rowOffset,
+        instance.anchorCol + pad.position.colOffset,
+      ));
+    }
+    return keys;
+  }, [composerWorkspace.selectedInstanceId, composerWorkspace.placedInstances]);
+
+  // Get currently occupied pads (for collision detection during placement)
+  const occupiedPads = useMemo(() => {
+    const occupied = new Set<string>();
+    const layout = state.workingLayout ?? state.activeLayout;
+    if (layout) {
+      for (const key of Object.keys(layout.padToVoice)) {
+        occupied.add(key);
+      }
+    }
+    return occupied;
+  }, [state.workingLayout, state.activeLayout]);
+
+  // Handle preset drop on grid
+  const handlePresetDrop = useCallback((presetId: string, anchorRow: number, anchorCol: number, isMirrored: boolean) => {
+    const presets = loadComposerPresets();
+    let preset = presets.find(p => p.id === presetId);
+    if (!preset) return;
+
+    if (isMirrored) {
+      preset = mirrorPreset(preset);
+    }
+
+    // Validate placement
+    const validation = validatePlacement(preset.pads, anchorRow, anchorCol, occupiedPads);
+    if (!validation.valid) {
+      window.alert(`Cannot place preset here:\n${validation.reasons.join('\n')}`);
+      return;
+    }
+
+    // Create placed instance
+    const instance: PlacedPresetInstance = {
+      id: generateId('pinst'),
+      presetId,
+      presetName: preset.name,
+      anchorRow,
+      anchorCol,
+      isMirrored,
+      pads: preset.pads,
+      config: preset.config,
+      lanes: preset.lanes,
+      events: preset.events,
+      boundingBox: preset.boundingBox,
+    };
+
+    // Assign pads to grid via BULK_ASSIGN_PADS
+    const padToVoice: Record<string, any> = {};
+    for (const pad of preset.pads) {
+      const absRow = anchorRow + pad.position.rowOffset;
+      const absCol = anchorCol + pad.position.colOffset;
+      const key = padKey(absRow, absCol);
+      const lane = preset.lanes.find(l => l.id === pad.laneId);
+      padToVoice[key] = {
+        id: pad.laneId,
+        name: lane?.name ?? 'Preset Pad',
+        sourceType: 'midi_track' as const,
+        sourceFile: `preset:${preset.name}`,
+        originalMidiNote: lane?.midiNote ?? 36,
+        color: lane?.color ?? '#888',
+      };
+    }
+    dispatch({ type: 'BULK_ASSIGN_PADS', payload: padToVoice });
+
+    // Set finger constraints for placed pads
+    for (const pad of preset.pads) {
+      const absRow = anchorRow + pad.position.rowOffset;
+      const absCol = anchorCol + pad.position.colOffset;
+      const key = padKey(absRow, absCol);
+      const handChar = pad.hand === 'left' ? 'L' : 'R';
+      const fingerMap: Record<string, number> = {
+        thumb: 1, index: 2, middle: 3, ring: 4, pinky: 5,
+      };
+      const fingerNum = fingerMap[pad.finger] ?? 2;
+      dispatch({
+        type: 'SET_FINGER_CONSTRAINT',
+        payload: { padKey: key, constraint: `${handChar}${fingerNum}` },
+      });
+    }
+
+    // Add to workspace state
+    composerDispatch({ type: 'PLACE_PRESET', instance });
+  }, [dispatch, occupiedPads]);
 
   // Resizable panel state
   const [leftWidth, setLeftWidth] = useState(LEFT_DEFAULT);
@@ -123,6 +257,55 @@ function PerformanceWorkspaceInner() {
       window.removeEventListener('mouseup', handleMouseUp);
     };
   }, []);
+
+  // Resolve selected preset for inspector
+  const inspectorPreset = useMemo(() => {
+    // Priority: placed instance > library selection
+    const instance = composerWorkspace.placedInstances.find(
+      i => i.id === composerWorkspace.selectedInstanceId
+    );
+    if (instance) {
+      // Reconstruct a ComposerPreset-like object from the instance
+      return {
+        preset: {
+          id: instance.presetId,
+          name: instance.presetName,
+          createdAt: 0,
+          updatedAt: 0,
+          pads: instance.pads,
+          config: instance.config,
+          lanes: instance.lanes,
+          events: instance.events,
+          handedness: 'both' as const,
+          mirrorEligible: false,
+          boundingBox: instance.boundingBox,
+          tags: [],
+        },
+        instance,
+      };
+    }
+    if (selectedPresetId) {
+      const presets = loadComposerPresets();
+      const preset = presets.find(p => p.id === selectedPresetId);
+      if (preset) return { preset, instance: null };
+    }
+    return null;
+  }, [selectedPresetId, composerWorkspace.selectedInstanceId, composerWorkspace.placedInstances]);
+
+  const handleRemoveInstance = useCallback((instanceId: string) => {
+    const instance = composerWorkspace.placedInstances.find(i => i.id === instanceId);
+    if (!instance) return;
+
+    // Remove pads from grid
+    for (const pad of instance.pads) {
+      const absRow = instance.anchorRow + pad.position.rowOffset;
+      const absCol = instance.anchorCol + pad.position.colOffset;
+      const key = padKey(absRow, absCol);
+      dispatch({ type: 'REMOVE_VOICE_FROM_PAD', payload: { padKey: key } });
+    }
+
+    composerDispatch({ type: 'REMOVE_INSTANCE', instanceId });
+  }, [composerWorkspace.placedInstances, dispatch]);
 
   const assignments = state.analysisResult?.executionPlan.fingerAssignments;
   const selectedCandidate = state.candidates.find(c => c.id === state.selectedCandidateId) ?? null;
@@ -194,7 +377,7 @@ function PerformanceWorkspaceInner() {
               title="Expand sidebar"
             >
               <span className="text-[10px] text-gray-500" style={{ writingMode: 'vertical-lr' }}>
-                {leftTab === 'sounds' ? 'Sounds' : 'Events'}
+                {leftTab === 'sounds' ? 'Sounds' : leftTab === 'events' ? 'Events' : 'Presets'}
               </span>
               <span className="text-[10px] text-gray-600">&#9656;</span>
             </button>
@@ -223,6 +406,16 @@ function PerformanceWorkspaceInner() {
                   Events
                 </button>
                 <button
+                  className={`flex-1 px-3 py-2 text-[11px] font-medium transition-colors ${
+                    leftTab === 'presets'
+                      ? 'text-gray-200 bg-gray-800/50 border-b-2 border-violet-500'
+                      : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800/30'
+                  }`}
+                  onClick={() => setLeftTab('presets')}
+                >
+                  Presets
+                </button>
+                <button
                   className="w-7 h-7 flex items-center justify-center text-gray-600 hover:text-gray-300 hover:bg-gray-700/50 transition-colors text-[10px] flex-shrink-0"
                   onClick={() => setLeftCollapsed(true)}
                   title="Collapse sidebar"
@@ -232,11 +425,27 @@ function PerformanceWorkspaceInner() {
               </div>
 
               {/* Tab content */}
-              <div className="p-3 overflow-y-auto flex-1 min-h-0">
+              <div className={`overflow-y-auto flex-1 min-h-0 ${leftTab === 'presets' ? '' : 'p-3'}`}>
                 {leftTab === 'sounds' ? (
                   <VoicePalette />
-                ) : (
+                ) : leftTab === 'events' ? (
                   <EventsPanel onionSkin={onionSkin} onToggleOnionSkin={() => setOnionSkin(!onionSkin)} />
+                ) : (
+                  <PresetLibraryPanel
+                    selectedPresetId={selectedPresetId}
+                    onSelectPreset={(id) => {
+                      setSelectedPresetId(id);
+                      if (id) composerDispatch({ type: 'SELECT_INSTANCE', instanceId: null });
+                    }}
+                    mirroredPresets={mirroredPresets}
+                    onToggleMirror={handleToggleMirror}
+                    placedInstances={composerWorkspace.placedInstances}
+                    selectedInstanceId={composerWorkspace.selectedInstanceId}
+                    onSelectInstance={(id) => {
+                      composerDispatch({ type: 'SELECT_INSTANCE', instanceId: id });
+                      if (id) setSelectedPresetId(null);
+                    }}
+                  />
                 )}
               </div>
             </div>
@@ -267,6 +476,8 @@ function PerformanceWorkspaceInner() {
                   onionSkin={onionSkin}
                   voiceConstraints={state.voiceConstraints}
                   gridLabels={viewSettings.gridLabels}
+                  highlightedInstancePads={highlightedInstancePads}
+                  onPresetDrop={handlePresetDrop}
                 />
               </div>
             </div>
@@ -348,7 +559,15 @@ function PerformanceWorkspaceInner() {
             {/* Tab content */}
             <div className="overflow-y-auto flex-1 min-h-0">
               {rightTab === 'costs' ? (
-                <ActiveLayoutSummary />
+                inspectorPreset ? (
+                  <PresetInspector
+                    preset={inspectorPreset.preset}
+                    instance={inspectorPreset.instance}
+                    onRemoveInstance={handleRemoveInstance}
+                  />
+                ) : (
+                  <ActiveLayoutSummary />
+                )
               ) : (
                 <div className="flex flex-col gap-3">
                   <LayoutOptionsPanel

--- a/src/ui/components/workspace/WorkspacePatternStudio.tsx
+++ b/src/ui/components/workspace/WorkspacePatternStudio.tsx
@@ -18,6 +18,17 @@ import { type Layout } from '../../../types/layout';
 import { RecipeEditorModal } from '../loop-editor/RecipeEditorModal';
 import { PatternSelector } from '../loop-editor/PatternSelector';
 import { savePreset, deletePreset, presetToLoopState, type PerformancePreset } from '../../persistence/presetStorage';
+import { saveComposerPreset } from '../../persistence/composerPresetStorage';
+import {
+  type PresetPad,
+  computeBoundingBox,
+  computeHandedness,
+  isMirrorEligible,
+  normalizePadPositions,
+} from '../../../types/composerPreset';
+import { type FingerType, type HandSide } from '../../../types/fingerModel';
+import { parsePadKey } from '../../../types/padGrid';
+import { getDisplayedLayout } from '../../state/projectState';
 
 const LANE_COLORS = ['#ef4444', '#f97316', '#22c55e', '#eab308', '#3b82f6', '#a855f7', '#ec4899', '#14b8a6'];
 const DEFAULT_MIDI_NOTES = [36, 38, 42, 46, 48, 60, 62, 64];
@@ -205,6 +216,78 @@ export function WorkspacePatternStudio() {
     savePreset(name, loopState);
   }, [loopState]);
 
+  /**
+   * Save current composer state as a ComposerPreset.
+   * Captures pad positions + finger assignments from the project's current layout.
+   */
+  const handleSaveComposerPreset = useCallback(() => {
+    if (loopState.events.size === 0 || loopState.lanes.length === 0) return;
+
+    const layout = getDisplayedLayout(projectState);
+    if (!layout) return;
+
+    // Build preset pads from the current layout's padToVoice mapping
+    // Match lane IDs to pads assigned via BULK_ASSIGN_PADS
+    const presetPads: PresetPad[] = [];
+    const fingerConstraints = layout.fingerConstraints ?? {};
+
+    for (const [padKeyStr, voice] of Object.entries(layout.padToVoice)) {
+      // Only include pads that belong to current composer lanes
+      const lane = loopState.lanes.find(l => l.id === voice.id);
+      if (!lane) continue;
+
+      const coord = parsePadKey(padKeyStr);
+      if (!coord) continue;
+
+      // Parse finger constraint (format: "L2" = left index, "R3" = right middle, etc.)
+      const constraint = fingerConstraints[padKeyStr];
+      let hand: HandSide = coord.col <= 4 ? 'left' : 'right';
+      let finger: FingerType = 'index';
+
+      if (constraint) {
+        const handChar = constraint.charAt(0);
+        const fingerNum = parseInt(constraint.charAt(1), 10);
+        if (handChar === 'L' || handChar === 'l') hand = 'left';
+        else if (handChar === 'R' || handChar === 'r') hand = 'right';
+        const fingerMap: Record<number, FingerType> = {
+          1: 'thumb', 2: 'index', 3: 'middle', 4: 'ring', 5: 'pinky',
+        };
+        finger = fingerMap[fingerNum] ?? 'index';
+      }
+
+      presetPads.push({
+        position: { rowOffset: coord.row, colOffset: coord.col },
+        laneId: lane.id,
+        finger,
+        hand,
+      });
+    }
+
+    if (presetPads.length === 0) {
+      window.alert('No pads assigned. Assign pads on the grid before saving a Composer Preset.');
+      return;
+    }
+
+    // Normalize to relative coordinates
+    const normalizedPads = normalizePadPositions(presetPads);
+    const handedness = computeHandedness(normalizedPads);
+
+    const name = window.prompt('Composer Preset name:', `Preset ${new Date().toLocaleDateString()}`);
+    if (!name) return;
+
+    saveComposerPreset({
+      name,
+      pads: normalizedPads,
+      config: loopState.config,
+      lanes: loopState.lanes,
+      events: Array.from(loopState.events.entries()),
+      handedness,
+      mirrorEligible: isMirrorEligible(handedness),
+      boundingBox: computeBoundingBox(normalizedPads),
+      tags: [],
+    });
+  }, [loopState, projectState]);
+
   const handleLoadPreset = useCallback((preset: PerformancePreset) => {
     setHasTouchedComposer(true);
     dispatch({ type: 'LOAD_LOOP_STATE', payload: presetToLoopState(preset) });
@@ -354,6 +437,19 @@ export function WorkspacePatternStudio() {
           title={loopState.events.size > 0 ? 'Save current pattern as preset' : 'Add events first'}
         >
           Save
+        </button>
+
+        <button
+          className={`px-2 py-1 text-xs rounded transition-colors ${
+            loopState.events.size > 0 && loopState.lanes.length > 0
+              ? 'bg-violet-600/20 text-violet-300 border border-violet-500/30 hover:bg-violet-600/30'
+              : 'bg-gray-800 text-gray-600 cursor-not-allowed'
+          }`}
+          onClick={handleSaveComposerPreset}
+          disabled={loopState.events.size === 0 || loopState.lanes.length === 0}
+          title="Save as Composer Preset (captures pad layout + finger assignments + events)"
+        >
+          Save Preset
         </button>
 
         <button

--- a/src/ui/persistence/composerPresetStorage.ts
+++ b/src/ui/persistence/composerPresetStorage.ts
@@ -1,0 +1,109 @@
+/**
+ * Composer Preset Storage.
+ *
+ * CRUD for ComposerPresets in localStorage.
+ * Presets are stored globally (not per-project) so they are
+ * accessible from any project and session.
+ */
+
+import { type ComposerPreset } from '../../types/composerPreset';
+import { generateId } from '../../utils/idGenerator';
+
+const STORAGE_KEY = 'pushflow_composer_presets';
+
+/** Load all composer presets from localStorage. */
+export function loadComposerPresets(): ComposerPreset[] {
+  try {
+    const json = localStorage.getItem(STORAGE_KEY);
+    if (!json) return [];
+    return JSON.parse(json) as ComposerPreset[];
+  } catch {
+    return [];
+  }
+}
+
+/** Save a new composer preset. Returns the saved preset. */
+export function saveComposerPreset(
+  preset: Omit<ComposerPreset, 'id' | 'createdAt' | 'updatedAt'>
+): ComposerPreset {
+  const now = Date.now();
+  const saved: ComposerPreset = {
+    ...preset,
+    id: generateId('cpreset'),
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const presets = loadComposerPresets();
+  presets.unshift(saved);
+  writePresets(presets);
+  return saved;
+}
+
+/** Update an existing preset by ID. Returns the updated preset or null if not found. */
+export function updateComposerPreset(
+  presetId: string,
+  updates: Partial<Omit<ComposerPreset, 'id' | 'createdAt'>>
+): ComposerPreset | null {
+  const presets = loadComposerPresets();
+  const index = presets.findIndex(p => p.id === presetId);
+  if (index === -1) return null;
+
+  const updated: ComposerPreset = {
+    ...presets[index],
+    ...updates,
+    updatedAt: Date.now(),
+  };
+  presets[index] = updated;
+  writePresets(presets);
+  return updated;
+}
+
+/** Duplicate a preset with a new name. Returns the new preset or null if source not found. */
+export function duplicateComposerPreset(
+  presetId: string,
+  newName?: string
+): ComposerPreset | null {
+  const presets = loadComposerPresets();
+  const source = presets.find(p => p.id === presetId);
+  if (!source) return null;
+
+  const now = Date.now();
+  const duplicate: ComposerPreset = {
+    ...source,
+    id: generateId('cpreset'),
+    name: newName ?? `${source.name} (copy)`,
+    createdAt: now,
+    updatedAt: now,
+  };
+  presets.unshift(duplicate);
+  writePresets(presets);
+  return duplicate;
+}
+
+/** Delete a preset by ID. */
+export function deleteComposerPreset(presetId: string): void {
+  const presets = loadComposerPresets().filter(p => p.id !== presetId);
+  writePresets(presets);
+}
+
+/** Rename a preset. Returns the updated preset or null if not found. */
+export function renameComposerPreset(
+  presetId: string,
+  newName: string
+): ComposerPreset | null {
+  return updateComposerPreset(presetId, { name: newName });
+}
+
+// ============================================================================
+// Internal
+// ============================================================================
+
+function writePresets(presets: ComposerPreset[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(presets));
+  } catch {
+    // localStorage full — silently fail
+    console.warn('Failed to save composer presets: localStorage may be full');
+  }
+}

--- a/src/ui/state/composerWorkspaceReducer.ts
+++ b/src/ui/state/composerWorkspaceReducer.ts
@@ -1,0 +1,68 @@
+/**
+ * Composer Workspace Reducer.
+ *
+ * Manages placed preset instances in the workspace assembly.
+ * This state persists with the project.
+ */
+
+import {
+  type ComposerWorkspaceState,
+  type PlacedPresetInstance,
+  createInitialComposerWorkspaceState,
+} from '../../types/composerPreset';
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+export type ComposerWorkspaceAction =
+  | { type: 'PLACE_PRESET'; instance: PlacedPresetInstance }
+  | { type: 'REMOVE_INSTANCE'; instanceId: string }
+  | { type: 'SELECT_INSTANCE'; instanceId: string | null }
+  | { type: 'CLEAR_ALL_INSTANCES' }
+  | { type: 'LOAD_WORKSPACE'; state: ComposerWorkspaceState };
+
+// ============================================================================
+// Reducer
+// ============================================================================
+
+export function composerWorkspaceReducer(
+  state: ComposerWorkspaceState,
+  action: ComposerWorkspaceAction,
+): ComposerWorkspaceState {
+  switch (action.type) {
+    case 'PLACE_PRESET':
+      return {
+        ...state,
+        placedInstances: [...state.placedInstances, action.instance],
+        selectedInstanceId: action.instance.id,
+      };
+
+    case 'REMOVE_INSTANCE':
+      return {
+        ...state,
+        placedInstances: state.placedInstances.filter(
+          inst => inst.id !== action.instanceId
+        ),
+        selectedInstanceId:
+          state.selectedInstanceId === action.instanceId
+            ? null
+            : state.selectedInstanceId,
+      };
+
+    case 'SELECT_INSTANCE':
+      return {
+        ...state,
+        selectedInstanceId: action.instanceId,
+      };
+
+    case 'CLEAR_ALL_INSTANCES':
+      return createInitialComposerWorkspaceState();
+
+    case 'LOAD_WORKSPACE':
+      return action.state;
+
+    default:
+      return state;
+  }
+}

--- a/test/engine/mapping/presetTransform.test.ts
+++ b/test/engine/mapping/presetTransform.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Preset Transform Tests.
+ *
+ * Tests for relative↔absolute conversion, mirror transform,
+ * and placement validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  toAbsolute,
+  allToAbsolute,
+  toRelative,
+  validatePlacement,
+  isPlacementValid,
+  getPlacementPadKeys,
+  mirrorPads,
+  mirrorPreset,
+  findValidAnchors,
+  snapToNearestValidAnchor,
+} from '../../../src/engine/mapping/presetTransform';
+import {
+  type PresetPad,
+  type ComposerPreset,
+  computeBoundingBox,
+  computeHandedness,
+  isMirrorEligible,
+} from '../../../src/types/composerPreset';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makePad(
+  rowOffset: number,
+  colOffset: number,
+  hand: 'left' | 'right' = 'left',
+  finger: 'thumb' | 'index' | 'middle' | 'ring' | 'pinky' = 'index',
+  laneId = 'lane-1',
+): PresetPad {
+  return {
+    position: { rowOffset, colOffset },
+    laneId,
+    finger,
+    hand,
+  };
+}
+
+function makePreset(pads: PresetPad[]): ComposerPreset {
+  const handedness = computeHandedness(pads);
+  return {
+    id: 'test',
+    name: 'Test',
+    createdAt: 0,
+    updatedAt: 0,
+    pads,
+    config: { barCount: 4, subdivision: '1/8', bpm: 120, beatsPerBar: 4 },
+    lanes: [],
+    events: [],
+    handedness,
+    mirrorEligible: isMirrorEligible(handedness),
+    boundingBox: computeBoundingBox(pads),
+    tags: [],
+  };
+}
+
+// ============================================================================
+// Relative ↔ Absolute Conversion
+// ============================================================================
+
+describe('toAbsolute', () => {
+  it('converts with zero anchor', () => {
+    const pad = makePad(1, 2);
+    expect(toAbsolute(pad, 0, 0)).toEqual({ row: 1, col: 2 });
+  });
+
+  it('converts with non-zero anchor', () => {
+    const pad = makePad(1, 2);
+    expect(toAbsolute(pad, 3, 4)).toEqual({ row: 4, col: 6 });
+  });
+
+  it('handles zero offset', () => {
+    const pad = makePad(0, 0);
+    expect(toAbsolute(pad, 5, 5)).toEqual({ row: 5, col: 5 });
+  });
+});
+
+describe('allToAbsolute', () => {
+  it('converts all pads', () => {
+    const pads = [makePad(0, 0), makePad(1, 1)];
+    const result = allToAbsolute(pads, 2, 3);
+    expect(result).toEqual([
+      { row: 2, col: 3 },
+      { row: 3, col: 4 },
+    ]);
+  });
+});
+
+describe('toRelative', () => {
+  it('converts back from absolute', () => {
+    expect(toRelative({ row: 4, col: 6 }, 3, 4)).toEqual({
+      rowOffset: 1,
+      colOffset: 2,
+    });
+  });
+
+  it('round-trips with toAbsolute', () => {
+    const pad = makePad(2, 3);
+    const abs = toAbsolute(pad, 1, 1);
+    const rel = toRelative(abs, 1, 1);
+    expect(rel).toEqual({ rowOffset: 2, colOffset: 3 });
+  });
+});
+
+// ============================================================================
+// Placement Validation
+// ============================================================================
+
+describe('validatePlacement', () => {
+  it('accepts valid placement at origin', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(1, 1, 'left')];
+    const result = validatePlacement(pads, 0, 0);
+    expect(result.valid).toBe(true);
+    expect(result.reasons).toHaveLength(0);
+  });
+
+  it('rejects out-of-bounds placement', () => {
+    const pads = [makePad(0, 0, 'right'), makePad(0, 1, 'right')];
+    const result = validatePlacement(pads, 7, 7); // (7,7) + (0,1) = (7,8) = out of bounds
+    expect(result.valid).toBe(false);
+    expect(result.reasons.length).toBeGreaterThan(0);
+    expect(result.reasons.some(r => r.includes('outside the 8×8 grid'))).toBe(true);
+  });
+
+  it('rejects hand zone violations', () => {
+    // Left-hand pad placed at column 7 (right-only zone)
+    const pads = [makePad(0, 0, 'left')];
+    const result = validatePlacement(pads, 0, 7);
+    expect(result.valid).toBe(false);
+    expect(result.reasons[0]).toContain('hand zone');
+  });
+
+  it('rejects collisions with occupied pads', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const occupied = new Set(['2,2']);
+    const result = validatePlacement(pads, 2, 2, occupied);
+    expect(result.valid).toBe(false);
+    expect(result.reasons[0]).toContain('collides');
+  });
+
+  it('accepts placement near occupied pads without collision', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const occupied = new Set(['2,3']);
+    const result = validatePlacement(pads, 2, 2, occupied);
+    expect(result.valid).toBe(true);
+  });
+
+  it('validates multi-pad preset with mixed hands', () => {
+    const pads = [
+      makePad(0, 0, 'left'),   // col 2 → left zone OK
+      makePad(0, 4, 'right'),  // col 6 → right zone OK
+    ];
+    const result = validatePlacement(pads, 2, 2);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('isPlacementValid', () => {
+  it('returns boolean shorthand', () => {
+    expect(isPlacementValid([makePad(0, 0, 'left')], 0, 0)).toBe(true);
+    expect(isPlacementValid([makePad(0, 0, 'right')], 7, 7)).toBe(true);
+    expect(isPlacementValid([makePad(0, 0, 'left')], 8, 0)).toBe(false);
+  });
+});
+
+describe('getPlacementPadKeys', () => {
+  it('returns pad keys for valid positions', () => {
+    const pads = [makePad(0, 0), makePad(1, 2)];
+    const keys = getPlacementPadKeys(pads, 1, 1);
+    expect(keys).toContain('1,1');
+    expect(keys).toContain('2,3');
+    expect(keys).toHaveLength(2);
+  });
+
+  it('filters out invalid positions', () => {
+    const pads = [makePad(0, 0), makePad(0, 1)];
+    const keys = getPlacementPadKeys(pads, 7, 7);
+    // (7,7) valid, (7,8) invalid
+    expect(keys).toContain('7,7');
+    expect(keys).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// Mirror Transform
+// ============================================================================
+
+describe('mirrorPads', () => {
+  it('flips column offsets horizontally', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(0, 2, 'left')];
+    const bbox = { rows: 1, cols: 3 };
+    const mirrored = mirrorPads(pads, bbox);
+
+    expect(mirrored[0].position.colOffset).toBe(2); // 3-1-0
+    expect(mirrored[1].position.colOffset).toBe(0); // 3-1-2
+  });
+
+  it('preserves row offsets', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(2, 1, 'left')];
+    const bbox = { rows: 3, cols: 2 };
+    const mirrored = mirrorPads(pads, bbox);
+
+    expect(mirrored[0].position.rowOffset).toBe(0);
+    expect(mirrored[1].position.rowOffset).toBe(2);
+  });
+
+  it('swaps hand assignment', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(0, 1, 'right')];
+    const bbox = { rows: 1, cols: 2 };
+    const mirrored = mirrorPads(pads, bbox);
+
+    expect(mirrored[0].hand).toBe('right');
+    expect(mirrored[1].hand).toBe('left');
+  });
+
+  it('preserves finger type', () => {
+    const pads = [
+      makePad(0, 0, 'left', 'thumb'),
+      makePad(0, 1, 'left', 'pinky'),
+    ];
+    const bbox = { rows: 1, cols: 2 };
+    const mirrored = mirrorPads(pads, bbox);
+
+    expect(mirrored[0].finger).toBe('thumb');
+    expect(mirrored[1].finger).toBe('pinky');
+  });
+
+  it('preserves laneId', () => {
+    const pads = [makePad(0, 0, 'left', 'index', 'my-lane')];
+    const bbox = { rows: 1, cols: 1 };
+    const mirrored = mirrorPads(pads, bbox);
+    expect(mirrored[0].laneId).toBe('my-lane');
+  });
+
+  it('single pad at origin stays at origin', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const bbox = { rows: 1, cols: 1 };
+    const mirrored = mirrorPads(pads, bbox);
+    expect(mirrored[0].position).toEqual({ rowOffset: 0, colOffset: 0 });
+  });
+});
+
+describe('mirrorPreset', () => {
+  it('flips handedness from left to right', () => {
+    const preset = makePreset([makePad(0, 0, 'left'), makePad(1, 1, 'left')]);
+    const mirrored = mirrorPreset(preset);
+    expect(mirrored.handedness).toBe('right');
+  });
+
+  it('flips handedness from right to left', () => {
+    const preset = makePreset([makePad(0, 0, 'right')]);
+    const mirrored = mirrorPreset(preset);
+    expect(mirrored.handedness).toBe('left');
+  });
+
+  it('keeps both as both', () => {
+    const preset = makePreset([makePad(0, 0, 'left'), makePad(0, 1, 'right')]);
+    const mirrored = mirrorPreset(preset);
+    expect(mirrored.handedness).toBe('both');
+  });
+
+  it('does not mutate original preset', () => {
+    const preset = makePreset([makePad(0, 0, 'left'), makePad(0, 2, 'left')]);
+    const originalPads = JSON.parse(JSON.stringify(preset.pads));
+    mirrorPreset(preset);
+    expect(preset.pads).toEqual(originalPads);
+  });
+
+  it('preserves bounding box dimensions', () => {
+    const preset = makePreset([makePad(0, 0, 'left'), makePad(2, 3, 'left')]);
+    const mirrored = mirrorPreset(preset);
+    expect(mirrored.boundingBox).toEqual(preset.boundingBox);
+  });
+
+  it('double mirror returns to original positions', () => {
+    const preset = makePreset([
+      makePad(0, 0, 'left', 'index'),
+      makePad(1, 2, 'left', 'middle'),
+      makePad(2, 1, 'left', 'ring'),
+    ]);
+    const doubleMirrored = mirrorPreset(mirrorPreset(preset));
+
+    for (let i = 0; i < preset.pads.length; i++) {
+      expect(doubleMirrored.pads[i].position).toEqual(preset.pads[i].position);
+      expect(doubleMirrored.pads[i].hand).toBe(preset.pads[i].hand);
+      expect(doubleMirrored.pads[i].finger).toBe(preset.pads[i].finger);
+    }
+  });
+});
+
+// ============================================================================
+// Mirror + Placement Combined
+// ============================================================================
+
+describe('mirror + placement', () => {
+  it('mirrored left-hand preset validates in right zone', () => {
+    // Original: left-hand pads in columns 0-2
+    const preset = makePreset([
+      makePad(0, 0, 'left', 'index'),
+      makePad(0, 1, 'left', 'middle'),
+      makePad(0, 2, 'left', 'ring'),
+    ]);
+
+    const mirrored = mirrorPreset(preset);
+
+    // All pads now right-hand, place at col 5 (right zone)
+    const result = validatePlacement(mirrored.pads, 3, 5);
+    expect(result.valid).toBe(true);
+  });
+
+  it('mirrored preset rejects placement in wrong zone', () => {
+    // Original: left-hand pads
+    const preset = makePreset([
+      makePad(0, 0, 'left'),
+      makePad(0, 1, 'left'),
+    ]);
+    const mirrored = mirrorPreset(preset);
+
+    // Now right-hand, try to place at col 0 (left zone) — should fail
+    const result = validatePlacement(mirrored.pads, 0, 0);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ============================================================================
+// Find Valid Anchors
+// ============================================================================
+
+describe('findValidAnchors', () => {
+  it('finds at least some valid positions for a small left-hand preset', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const anchors = findValidAnchors(pads);
+    expect(anchors.length).toBeGreaterThan(0);
+    // Left hand valid in cols 0-4
+    for (const anchor of anchors) {
+      expect(anchor.col).toBeLessThanOrEqual(4);
+    }
+  });
+
+  it('respects occupied pads', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const occupied = new Set(['0,0', '0,1', '0,2', '0,3', '0,4']);
+    const anchorsWithOccupied = findValidAnchors(pads, occupied);
+    // Row 0 should have no valid left-hand anchors since all cols 0-4 are occupied
+    const row0 = anchorsWithOccupied.filter(a => a.row === 0);
+    expect(row0).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// Snap to Nearest Valid Anchor
+// ============================================================================
+
+describe('snapToNearestValidAnchor', () => {
+  it('returns cursor position when valid', () => {
+    const pads = [makePad(0, 0, 'left')];
+    const result = snapToNearestValidAnchor(2, 2, pads);
+    expect(result).toEqual({ row: 2, col: 2 });
+  });
+
+  it('snaps to nearest valid when cursor is invalid', () => {
+    // Left-hand pad cannot be at col 7
+    const pads = [makePad(0, 0, 'left')];
+    const result = snapToNearestValidAnchor(0, 7, pads);
+    expect(result).not.toBeNull();
+    // Should snap to col 4 or closer valid position
+    expect(result!.col).toBeLessThanOrEqual(4);
+  });
+
+  it('returns null when no valid position exists', () => {
+    // A pad that spans the entire grid width — impossible to place
+    const pads: PresetPad[] = [];
+    for (let c = 0; c < 9; c++) {
+      pads.push(makePad(0, c, 'left'));
+    }
+    const result = snapToNearestValidAnchor(0, 0, pads);
+    expect(result).toBeNull();
+  });
+});

--- a/test/types/composerPreset.test.ts
+++ b/test/types/composerPreset.test.ts
@@ -1,0 +1,221 @@
+/**
+ * ComposerPreset type tests.
+ *
+ * Validates bounding box computation, handedness detection,
+ * mirror eligibility, normalization, and serialization round-trips.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  type PresetPad,
+  type ComposerPreset,
+  computeBoundingBox,
+  computeHandedness,
+  isMirrorEligible,
+  normalizePadPositions,
+  createInitialComposerWorkspaceState,
+} from '../../src/types/composerPreset';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function makePad(
+  rowOffset: number,
+  colOffset: number,
+  hand: 'left' | 'right' = 'left',
+  finger: 'thumb' | 'index' | 'middle' | 'ring' | 'pinky' = 'index',
+  laneId = 'lane-1',
+): PresetPad {
+  return {
+    position: { rowOffset, colOffset },
+    laneId,
+    finger,
+    hand,
+  };
+}
+
+function makePreset(pads: PresetPad[]): ComposerPreset {
+  const handedness = computeHandedness(pads);
+  return {
+    id: 'test-preset',
+    name: 'Test Preset',
+    createdAt: 1000,
+    updatedAt: 1000,
+    pads,
+    config: { barCount: 4, subdivision: '1/8', bpm: 120, beatsPerBar: 4 },
+    lanes: [{ id: 'lane-1', name: 'Kick', color: '#ff0000', midiNote: 36, orderIndex: 0, isMuted: false, isSolo: false }],
+    events: [['lane-1:0', { laneId: 'lane-1', stepIndex: 0, velocity: 100 }]],
+    handedness,
+    mirrorEligible: isMirrorEligible(handedness),
+    boundingBox: computeBoundingBox(pads),
+    tags: [],
+  };
+}
+
+// ============================================================================
+// Bounding Box
+// ============================================================================
+
+describe('computeBoundingBox', () => {
+  it('returns zero for empty pads', () => {
+    expect(computeBoundingBox([])).toEqual({ rows: 0, cols: 0 });
+  });
+
+  it('computes 1×1 for single pad at origin', () => {
+    const pads = [makePad(0, 0)];
+    expect(computeBoundingBox(pads)).toEqual({ rows: 1, cols: 1 });
+  });
+
+  it('computes correct box for multi-pad preset', () => {
+    const pads = [makePad(0, 0), makePad(2, 3), makePad(1, 1)];
+    expect(computeBoundingBox(pads)).toEqual({ rows: 3, cols: 4 });
+  });
+
+  it('handles pads in a single row', () => {
+    const pads = [makePad(0, 0), makePad(0, 5)];
+    expect(computeBoundingBox(pads)).toEqual({ rows: 1, cols: 6 });
+  });
+
+  it('handles pads in a single column', () => {
+    const pads = [makePad(0, 0), makePad(4, 0)];
+    expect(computeBoundingBox(pads)).toEqual({ rows: 5, cols: 1 });
+  });
+});
+
+// ============================================================================
+// Handedness
+// ============================================================================
+
+describe('computeHandedness', () => {
+  it('returns both for empty pads', () => {
+    expect(computeHandedness([])).toBe('both');
+  });
+
+  it('detects left-only', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(1, 1, 'left')];
+    expect(computeHandedness(pads)).toBe('left');
+  });
+
+  it('detects right-only', () => {
+    const pads = [makePad(0, 0, 'right'), makePad(1, 1, 'right')];
+    expect(computeHandedness(pads)).toBe('right');
+  });
+
+  it('detects both hands', () => {
+    const pads = [makePad(0, 0, 'left'), makePad(1, 1, 'right')];
+    expect(computeHandedness(pads)).toBe('both');
+  });
+});
+
+// ============================================================================
+// Mirror Eligibility
+// ============================================================================
+
+describe('isMirrorEligible', () => {
+  it('left-hand presets are eligible', () => {
+    expect(isMirrorEligible('left')).toBe(true);
+  });
+
+  it('right-hand presets are eligible', () => {
+    expect(isMirrorEligible('right')).toBe(true);
+  });
+
+  it('both-hand presets are not eligible', () => {
+    expect(isMirrorEligible('both')).toBe(false);
+  });
+});
+
+// ============================================================================
+// Normalization
+// ============================================================================
+
+describe('normalizePadPositions', () => {
+  it('returns empty for empty input', () => {
+    expect(normalizePadPositions([])).toEqual([]);
+  });
+
+  it('no-ops already normalized pads', () => {
+    const pads = [makePad(0, 0), makePad(1, 2)];
+    const normalized = normalizePadPositions(pads);
+    expect(normalized).toEqual(pads);
+  });
+
+  it('shifts pads to origin', () => {
+    const pads = [makePad(3, 5), makePad(5, 7)];
+    const normalized = normalizePadPositions(pads);
+    expect(normalized[0].position).toEqual({ rowOffset: 0, colOffset: 0 });
+    expect(normalized[1].position).toEqual({ rowOffset: 2, colOffset: 2 });
+  });
+
+  it('preserves non-position fields', () => {
+    const pads = [makePad(2, 3, 'right', 'pinky', 'lane-x')];
+    const normalized = normalizePadPositions(pads);
+    expect(normalized[0].hand).toBe('right');
+    expect(normalized[0].finger).toBe('pinky');
+    expect(normalized[0].laneId).toBe('lane-x');
+  });
+});
+
+// ============================================================================
+// Serialization Round-Trip
+// ============================================================================
+
+describe('ComposerPreset serialization', () => {
+  it('survives JSON round-trip', () => {
+    const preset = makePreset([
+      makePad(0, 0, 'left', 'index', 'lane-1'),
+      makePad(1, 2, 'left', 'middle', 'lane-1'),
+    ]);
+
+    const json = JSON.stringify(preset);
+    const restored = JSON.parse(json) as ComposerPreset;
+
+    expect(restored.id).toBe(preset.id);
+    expect(restored.name).toBe(preset.name);
+    expect(restored.pads).toEqual(preset.pads);
+    expect(restored.config).toEqual(preset.config);
+    expect(restored.lanes).toEqual(preset.lanes);
+    expect(restored.events).toEqual(preset.events);
+    expect(restored.handedness).toBe(preset.handedness);
+    expect(restored.mirrorEligible).toBe(preset.mirrorEligible);
+    expect(restored.boundingBox).toEqual(preset.boundingBox);
+    expect(restored.tags).toEqual(preset.tags);
+  });
+
+  it('preserves finger assignment through round-trip', () => {
+    const preset = makePreset([
+      makePad(0, 0, 'right', 'thumb', 'lane-1'),
+      makePad(0, 1, 'right', 'index', 'lane-1'),
+      makePad(0, 2, 'right', 'middle', 'lane-1'),
+    ]);
+
+    const restored = JSON.parse(JSON.stringify(preset)) as ComposerPreset;
+
+    expect(restored.pads[0].finger).toBe('thumb');
+    expect(restored.pads[0].hand).toBe('right');
+    expect(restored.pads[1].finger).toBe('index');
+    expect(restored.pads[2].finger).toBe('middle');
+  });
+
+  it('preserves event data through round-trip', () => {
+    const preset = makePreset([makePad(0, 0)]);
+
+    const restored = JSON.parse(JSON.stringify(preset)) as ComposerPreset;
+    expect(restored.events).toHaveLength(1);
+    expect(restored.events[0][0]).toBe('lane-1:0');
+    expect(restored.events[0][1].velocity).toBe(100);
+  });
+});
+
+// ============================================================================
+// Initial State
+// ============================================================================
+
+describe('createInitialComposerWorkspaceState', () => {
+  it('creates empty state', () => {
+    const state = createInitialComposerWorkspaceState();
+    expect(state.placedInstances).toEqual([]);
+    expect(state.selectedInstanceId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a complete Composer preset system for the Performance Workspace, enabling users to author, store, and place reusable pad layouts with explicit finger assignments and quantized event patterns. Presets are stored globally in localStorage and can be placed on the 8×8 grid with full validation, collision detection, and mirror transform support.

## Key Changes

### Core Types & Data Model
- **`ComposerPreset`** type: Bundles relative pad layout, finger assignments (mandatory), and quantized event pattern as a single authored unit
- **`PlacedPresetInstance`** type: Represents a placed preset snapshot in the workspace with absolute anchor position
- **`ComposerWorkspaceState`**: Manages placed instances and selection state
- Relative coordinate system with `RelativePadPosition` for preset-agnostic layout storage
- Computed metadata: handedness detection, mirror eligibility, bounding box calculation

### Preset Transform Engine (`presetTransform.ts`)
- **Coordinate conversion**: `toAbsolute()`, `allToAbsolute()`, `toRelative()` for relative↔absolute translation
- **Placement validation**: `validatePlacement()` checks grid bounds, hand zone constraints, and collision detection
- **Mirror transform**: `mirrorPads()` and `mirrorPreset()` flip layouts horizontally with hand swapping
- **Anchor snapping**: `findValidAnchors()` and `snapToNearestValidAnchor()` for intelligent placement assistance

### UI Components
- **`PresetCard`**: Library card view with mini grid preview, timeline strip, hand indicator, and drag-to-workspace support
- **`PresetLibraryPanel`**: Browsable preset library with search, CRUD operations (duplicate, rename, delete), and mirror toggle
- **`PresetInspector`**: Right-panel inspector showing grid preview, finger assignments, event pattern, and diagnostic metrics
- Drag-and-drop integration via `COMPOSER_PRESET_DRAG_TYPE` for workspace placement

### Storage & Persistence
- **`composerPresetStorage.ts`**: localStorage-backed CRUD for global preset library
- `loadComposerPresets()`, `saveComposerPreset()`, `updateComposerPreset()`, `duplicateComposerPreset()`, `deleteComposerPreset()`, `renameComposerPreset()`
- Presets are globally accessible across projects and sessions

### Workspace Integration
- **`composerWorkspaceReducer`**: State management for placed instances with actions: `PLACE_PRESET`, `REMOVE_INSTANCE`, `SELECT_INSTANCE`, `CLEAR_ALL_INSTANCES`, `LOAD_WORKSPACE`
- **`PerformanceWorkspace`**: Added "Presets" tab in left panel, preset drop handling with validation, occupied pad tracking for collision detection
- **`WorkspacePatternStudio`**: `handleSaveComposerPreset()` captures current layout + finger assignments as a new preset
- **`InteractiveGrid`**: Drag-and-drop target for preset placement with validation feedback

### Testing
- Comprehensive test suite for preset transforms (relative↔absolute, validation, mirroring)
- Type validation tests for bounding box, handedness, mirror eligibility, normalization
- Round-trip serialization tests

## Notable Implementation Details

- **Relative coordinates**: Presets store pad positions relative to bounding box origin (0,0 = bottom-left), enabling placement at any grid position via anchor translation
- **Mandatory finger assignment**: Every pad in a preset must have explicit finger type and hand assignment for playability validation
- **Hand zone validation**: Placement respects left/right hand zones (columns 0-3 for left, 4-7 for right)
- **Mirror eligibility**: Only single-hand presets (left or right) can be mirrored; both-hand presets are not eligible
- **Collision detection**: Placement validation checks against occupied pads from the current layout
- **Snapshot instances**: Placed instances capture preset data at placement time, surviving preset edits/deletion
- **Diagnostic framing**: Metric breakdown in inspector presented as model validation aids, not prescriptive rules

https://claude.ai/code/session_01UkQPSbG8pQimkCzybnXDj4