### PR TITLE
Fix GitHub Pages case-sensitive base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1e1e2e" />
-    <link rel="icon" href="/pushflow-modified/favicon.svg" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="/pushflow-modified/pwa-192x192.png" />
+    <link rel="icon" href="/PushFlow-Modified/favicon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/PushFlow-Modified/pwa-192x192.png" />
     <title>PushFlow</title>
   </head>
   <body>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,10 +6,8 @@ import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-const isProduction = process.env.NODE_ENV === 'production'
-
-export default defineConfig({
-  base: isProduction ? '/pushflow-modified/' : '/',
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/PushFlow-Modified/' : '/',
   plugins: [
     react(),
     VitePWA({
@@ -22,8 +20,8 @@ export default defineConfig({
         theme_color: '#1e1e2e',
         background_color: '#1e1e2e',
         display: 'standalone',
-        scope: '/pushflow-modified/',
-        start_url: '/pushflow-modified/',
+        scope: '/PushFlow-Modified/',
+        start_url: '/PushFlow-Modified/',
         icons: [
           {
             src: 'pwa-192x192.png',
@@ -53,4 +51,4 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
-})
+}))


### PR DESCRIPTION
## Summary

- Fix case mismatch causing all assets to 404 on GitHub Pages
- Repo name is `PushFlow-Modified` but base path was set to `/pushflow-modified/`
- GitHub Pages URLs are case-sensitive, so all JS/CSS/icons failed to load
- Also switched from `process.env.NODE_ENV` to Vite's `command` parameter for reliable build detection

## Test plan

- [ ] Merge to main and verify deploy workflow succeeds
- [ ] Visit https://tgalloway1.github.io/PushFlow-Modified/ and confirm the app loads
- [ ] Verify no 404 errors in browser console

https://claude.ai/code/session_017snGDFHjNvAoPwKexsHFQP