### PR TITLE
Fix 9 UI issues: finger display, timeline, grid, events, library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,26 @@ When an optimizer supports restarts, the output must include:
 
 This contract is implementation-agnostic. Types may change, but the semantic obligations remain.
 
+## UI Non-Regression Rules
+
+These rules protect against recurring UI regressions. Violating them requires explicit user approval.
+
+### Timeline Rules
+- The timeline must always fill its container width in auto-fit mode. After MIDI import, the timeline must recalculate its width to fill the container. Do not use a fixed/default width that ignores container size.
+- Timeline note pills must display hand+finger (e.g., "L2"), never just the finger number alone (e.g., "2").
+- Clicking any note in the timeline must highlight ALL notes at the same time position (same moment/event). Single-note-only selection is a regression.
+
+### Finger Assignment Display Rules
+- The Sounds panel `FingerAssignmentInput` must show solver suggestions (at reduced opacity) when no user constraint is set. The `(XX)` parenthesized text format must NOT be used for finger display next to pad positions.
+- When the "Show Finger Assignment" toggle is enabled in grid settings, the grid must display finger assignments from solver analysis, not just user-set constraints. This toggle must always produce visible results when analysis data exists, regardless of whether user constraints are set.
+
+### Project Library Rules
+- Project cards in the library must display actual project data (BPM, sound count, bar length, event count, created date, last visited date). Mock/placeholder data must not appear on project cards.
+
+### Sound Grouping Rules
+- When groups exist, ungrouped sounds must be labeled "Ungrouped", not "On Grid" (which is confusing since grouped sounds are also on the grid).
+- Cmd+G (Ctrl+G) must toggle: group selected ungrouped sounds, or ungroup if all selected sounds are in the same group.
+
 ## Final Reminder
 
 Do not let legacy docs, current file structure, or existing engine internals define the product by accident.

--- a/src/ui/components/EventsPanel.tsx
+++ b/src/ui/components/EventsPanel.tsx
@@ -256,7 +256,15 @@ export function EventsPanel({
         </div>
       </div>
 
-      <div ref={listRef} className="overflow-y-auto space-y-0.5" style={{ maxHeight: 'calc(100vh - 280px)' }}>
+      {/* Column header */}
+      <div className="flex items-center gap-2 px-2 py-1 text-pf-micro font-mono text-[var(--text-tertiary)] uppercase tracking-wider border-b border-[var(--border-subtle)]/30">
+        <span className="w-8 flex-shrink-0">#</span>
+        <span className="flex-1">Beat</span>
+        <span className="flex-shrink-0 w-10 text-right">Cost</span>
+        <span className="flex-shrink-0 w-8 text-right">Notes</span>
+      </div>
+
+      <div ref={listRef} className="overflow-y-auto space-y-0.5" style={{ maxHeight: 'calc(100vh - 310px)' }}>
         {moments.map((moment) => (
           <MomentRow
             key={moment.momentIndex}
@@ -305,8 +313,8 @@ function MomentRow({
     >
       <div className="flex items-center gap-2">
         {/* Event label */}
-        <span className={`text-pf-xs font-mono w-14 flex-shrink-0 ${isSelected ? 'text-blue-300' : 'text-[var(--text-tertiary)]'}`}>
-          Event {String(moment.momentIndex + 1).padStart(2, '0')}
+        <span className={`text-pf-xs font-mono w-8 flex-shrink-0 ${isSelected ? 'text-blue-300' : 'text-[var(--text-tertiary)]'}`}>
+          {String(moment.momentIndex + 1).padStart(2, '0')}
         </span>
 
         {/* Beat position */}

--- a/src/ui/components/Homepage/PerformanceCard.tsx
+++ b/src/ui/components/Homepage/PerformanceCard.tsx
@@ -2,48 +2,59 @@
  * PerformanceCard.
  *
  * Compact card for the Active Performances grid.
- * Shows pad-grid thumbnail, title, improvement score, progress, and metadata.
+ * Shows pad-grid thumbnail, title, and real project metadata.
  */
 
 import { type ProjectLibraryEntry } from '../../persistence/projectStorage';
 import { type ProjectState } from '../../state/projectState';
-import { type ProjectMockData } from './homepageDemoData';
 import { MiniGridPreview } from '../panels/MiniGridPreview';
-import { ImprovementBadge } from './ImprovementBadge';
 
 interface PerformanceCardProps {
   project: ProjectLibraryEntry;
   projectState: ProjectState | null;
-  mockData: ProjectMockData;
   onOpen: () => void;
   onDelete: () => void;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  'in-progress': 'bg-blue-500/15 text-blue-400',
-  'needs-review': 'bg-amber-500/15 text-amber-400',
-  'practice-ready': 'bg-green-500/15 text-green-400',
-  'mostly-mastered': 'bg-purple-500/15 text-purple-400',
-  'archived': 'bg-[var(--bg-hover)] text-[var(--text-secondary)]',
-};
+/** Format an ISO date string as a relative label. */
+function relativeDate(iso: string): string {
+  try {
+    const date = new Date(iso);
+    const now = Date.now();
+    const diffMs = now - date.getTime();
+    const diffMin = Math.floor(diffMs / 60000);
+    if (diffMin < 1) return 'Just now';
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    const diffDays = Math.floor(diffHr / 24);
+    if (diffDays < 30) return `${diffDays}d ago`;
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
 
-const PROGRESS_COLORS: Record<string, string> = {
-  'in-progress': 'bg-blue-500',
-  'needs-review': 'bg-amber-500',
-  'practice-ready': 'bg-green-500',
-  'mostly-mastered': 'bg-purple-500',
-  'archived': 'bg-gray-500',
-};
+/** Format an ISO date string as a short date. */
+function shortDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
 
 export function PerformanceCard({
   project,
   projectState,
-  mockData,
   onOpen,
   onDelete,
 }: PerformanceCardProps) {
-  const statusClass = STATUS_COLORS[mockData.status] ?? 'bg-[var(--bg-hover)] text-[var(--text-secondary)]';
-  const progressColor = PROGRESS_COLORS[mockData.status] ?? 'bg-gray-500';
+  // Derive real data from project index entry and loaded state
+  const tempo = (projectState?.tempo ?? (project as any).tempo) || 120;
+  const soundCount = projectState?.soundStreams.length ?? project.soundCount;
+  const eventCount = project.eventCount;
+  const durationBars = (project as any).durationBars ?? 0;
 
   return (
     <div
@@ -77,37 +88,23 @@ export function PerformanceCard({
         </div>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <h3 className="text-pf-base font-medium text-[var(--text-primary)] truncate">{project.name}</h3>
-            <ImprovementBadge score={mockData.improvementScore} />
-          </div>
+          <h3 className="text-pf-base font-medium text-[var(--text-primary)] truncate">{project.name}</h3>
 
-          {/* Status */}
-          <span className={`inline-block text-pf-micro px-1.5 py-0.5 rounded-pf-sm mt-1 font-medium ${statusClass}`}>
-            {mockData.statusLabel}
+          {/* BPM badge */}
+          <span className="inline-block text-pf-micro px-1.5 py-0.5 rounded-pf-sm mt-1 font-medium bg-[var(--bg-hover)] text-[var(--text-secondary)]">
+            {tempo} BPM
           </span>
 
-          {/* Practice status label */}
-          <p className="text-pf-xs text-[var(--text-tertiary)] mt-1.5">
-            Practice status
-          </p>
-
-          {/* Metadata */}
-          <div className="text-pf-xs text-[var(--text-tertiary)] mt-1 space-y-0.5">
-            <p>Sections: <span className="text-[var(--text-secondary)]">{mockData.sectionsCount}</span></p>
-            <p>Hours practiced: <span className="text-[var(--text-secondary)]">{mockData.minHours}</span></p>
-            <p>Last opened: <span className="text-[var(--text-secondary)]">{mockData.lastPracticedLabel}</span></p>
+          {/* Real metadata */}
+          <div className="text-pf-xs text-[var(--text-tertiary)] mt-2 space-y-0.5">
+            <p>Sounds: <span className="text-[var(--text-secondary)]">{soundCount}</span></p>
+            {durationBars > 0 && (
+              <p>Length: <span className="text-[var(--text-secondary)]">{durationBars} bar{durationBars !== 1 ? 's' : ''}</span></p>
+            )}
+            <p>Events: <span className="text-[var(--text-secondary)]">{eventCount}</span></p>
+            <p>Created: <span className="text-[var(--text-secondary)]">{shortDate(project.createdAt)}</span></p>
+            <p>Last visited: <span className="text-[var(--text-secondary)]">{relativeDate(project.updatedAt)}</span></p>
           </div>
-        </div>
-      </div>
-
-      {/* Progress bar */}
-      <div className="mt-2.5">
-        <div className="h-1 bg-[var(--bg-input)] rounded-full overflow-hidden">
-          <div
-            className={`h-full rounded-full ${progressColor}`}
-            style={{ width: `${mockData.progressPercent}%` }}
-          />
         </div>
       </div>
     </div>

--- a/src/ui/components/InteractiveGrid.tsx
+++ b/src/ui/components/InteractiveGrid.tsx
@@ -124,10 +124,11 @@ export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick,
     return result;
   }, [layout, soundStreamLookup]);
 
+  // Whether to show finger labels on pads (user constraints always show; solver assignments show when toggle is on)
+  const showFingerLabels = gridLabels?.showFingerAssignment ?? true;
+
   // Build per-pad summary from assignments, overlaying voiceConstraints.
-  // Per invariant 7 (no auto grid layout): finger labels only display when the user
-  // has explicitly set a voiceConstraint. Solver-computed fingers (a.assignedHand/a.finger)
-  // are used for hand coloring (glow) but NOT displayed as finger labels on pads.
+  // Finger labels show user constraints always, and solver assignments when showFingerAssignment toggle is on.
   const padSummaries = useMemo(() => {
     const map = new Map<string, PadSummary>();
     if (!assignments) return map;
@@ -147,22 +148,26 @@ export function InteractiveGrid({ assignments, selectedEventIndex, onEventClick,
         };
         map.set(key, summary);
       }
-      // Use solver hand for glow coloring (visual feedback), but only show
-      // finger labels when the user has explicitly set a voiceConstraint.
+      // Use solver hand for glow coloring (visual feedback).
+      // Show finger labels from user constraints or solver assignments (when toggle is on).
       const voice = soundStreamLookup.forAssignment(a.voiceId, a.noteNumber);
       const constraint = voice ? voiceConstraints[voice.id] : undefined;
       const effectiveHand = constraint?.hand ?? a.assignedHand;
       summary.hands.add(effectiveHand);
-      // Only add finger label if user explicitly set a constraint
+      // Add finger label: user constraint takes priority, then solver assignment
       if (constraint?.hand && constraint?.finger) {
         const handChar = constraint.hand === 'left' ? 'L' : 'R';
         const fingerNum = FINGER_ABBREV[constraint.finger] ?? constraint.finger;
+        summary.fingers.add(`${handChar}${fingerNum}`);
+      } else if (showFingerLabels && a.assignedHand && (a.assignedHand as string) !== 'raw' && (a.assignedHand as string) !== 'Unplayable' && a.finger && (a.finger as string) !== 'unassigned') {
+        const handChar = a.assignedHand === 'left' ? 'L' : 'R';
+        const fingerNum = FINGER_ABBREV[a.finger] ?? a.finger;
         summary.fingers.add(`${handChar}${fingerNum}`);
       }
       summary.hitCount++;
     }
     return map;
-  }, [assignments, soundStreamLookup, voiceConstraints]);
+  }, [assignments, soundStreamLookup, voiceConstraints, showFingerLabels]);
 
   // Selected pads: all assignments at the same start time as the selected event
   // Also builds a map of padKey → finger label for the selected event

--- a/src/ui/components/UnifiedTimeline.tsx
+++ b/src/ui/components/UnifiedTimeline.tsx
@@ -131,16 +131,19 @@ export function UnifiedTimeline({ highlightedStreamIds }: UnifiedTimelineProps =
   }, [state.isPlaying, state.currentTime, dispatch]);
 
   // Auto-fit zoom: measure container width and fill it with the clip
+  // Re-measure when totalDuration changes (e.g. after MIDI import)
   const [containerWidth, setContainerWidth] = useState(0);
   useEffect(() => {
     const el = scrollContainerRef.current;
     if (!el) return;
     const measure = () => setContainerWidth(el.clientWidth);
     measure();
+    // Re-measure after a frame to catch layout shifts from content changes
+    const raf = requestAnimationFrame(measure);
     const observer = new ResizeObserver(measure);
     observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
+    return () => { observer.disconnect(); cancelAnimationFrame(raf); };
+  }, [totalDuration]);
 
   // Auto-fit: scale so full bar-snapped duration fills the container width exactly
   const autoFitZoom = containerWidth > 0 && totalDuration > 0
@@ -314,6 +317,14 @@ export function UnifiedTimeline({ highlightedStreamIds }: UnifiedTimelineProps =
     }
   }, [state.selectedEventIndex, streamAssignments, minTime, zoom]);
 
+  // ─── Selected moment time (for multi-note highlighting) ─────────────────
+  const selectedMomentTime = useMemo(() => {
+    if (state.selectedEventIndex === null) return null;
+    const allA = Array.from(streamAssignments.values()).flat();
+    const sel = allA.find(a => a.eventIndex === state.selectedEventIndex);
+    return sel?.startTime ?? null;
+  }, [state.selectedEventIndex, streamAssignments]);
+
   // ─── Handlers ────────────────────────────────────────────────────────────
 
   const handleImportClick = useCallback(() => {
@@ -337,7 +348,19 @@ export function UnifiedTimeline({ highlightedStreamIds }: UnifiedTimelineProps =
 
   const handleEventClick = useCallback((eventIndex: number) => {
     dispatch({ type: 'SELECT_EVENT', payload: eventIndex });
-  }, [dispatch]);
+    // Also select the moment so all simultaneous notes highlight
+    const allAssignments = Array.from(streamAssignments.values()).flat();
+    const clicked = allAssignments.find(a => a.eventIndex === eventIndex);
+    if (clicked) {
+      // Find moment index: count distinct start times up to this one
+      const uniqueTimes = [...new Set(allAssignments.map(a => a.startTime))].sort((a, b) => a - b);
+      const EPSILON = 0.001;
+      const momentIdx = uniqueTimes.findIndex(t => Math.abs(t - clicked.startTime) < EPSILON);
+      if (momentIdx >= 0) {
+        dispatch({ type: 'SELECT_MOMENT', payload: momentIdx });
+      }
+    }
+  }, [dispatch, streamAssignments]);
 
   // ─── Render ──────────────────────────────────────────────────────────────
 
@@ -587,7 +610,8 @@ export function UnifiedTimeline({ highlightedStreamIds }: UnifiedTimelineProps =
                     const finger = a.finger as string | null;
                     const isRaw = hand === 'raw' || finger === 'unassigned';
                     const fingerLabel = (finger && finger !== 'unassigned') ? FINGER_ABBREV[finger] ?? finger : '';
-                    const isSelected = a.eventIndex === state.selectedEventIndex;
+                    const isSelected = a.eventIndex === state.selectedEventIndex
+                      || (selectedMomentTime !== null && Math.abs(a.startTime - selectedMomentTime) < 0.001);
                     const handPrefix = a.assignedHand === 'left' ? 'L' : a.assignedHand === 'right' ? 'R' : '';
 
                     const isUnplayable = hand === 'Unplayable';
@@ -625,7 +649,7 @@ export function UnifiedTimeline({ highlightedStreamIds }: UnifiedTimelineProps =
                       >
                         {fingerLabel && (
                           <span className="text-[7px] font-bold leading-none" style={{ color: pillText }}>
-                            {fingerLabel}
+                            {handPrefix}{fingerLabel}
                           </span>
                         )}
                       </button>

--- a/src/ui/components/VoicePalette.tsx
+++ b/src/ui/components/VoicePalette.tsx
@@ -14,7 +14,7 @@ import { buildSoundStreamLookup } from '../analysis/soundStreamLookup';
 import { generateId } from '../../utils/idGenerator';
 import { formatPadPosition } from '../../utils/padPosition';
 import { FingerAssignmentInput, type FingerAssignmentValue } from './shared/FingerAssignmentInput';
-import { type FingerType } from '../../types/fingerModel';
+import { type FingerType, type HandSide } from '../../types/fingerModel';
 
 const FINGER_ABBREV: Record<string, string> = {
   thumb: '1', index: '2', middle: '3', ring: '4', pinky: '5',
@@ -37,28 +37,44 @@ export function VoicePalette() {
     [state.soundStreams],
   );
 
-  // Cmd+G to group selected streams
+  // Cmd+G to group/ungroup selected streams
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'g' && selectedStreamIds.size > 0) {
         e.preventDefault();
-        const group: LaneGroup = {
-          groupId: generateId('grp'),
-          name: `Group ${state.laneGroups.length + 1}`,
-          color: COLOR_PALETTE[state.laneGroups.length % COLOR_PALETTE.length],
-          orderIndex: state.laneGroups.length,
-          isCollapsed: false,
-        };
-        dispatch({ type: 'CREATE_LANE_GROUP', payload: group });
+        // Check if all selected streams are in the same group → ungroup
+        const groupIds = new Set<string | null>();
         for (const streamId of selectedStreamIds) {
-          dispatch({ type: 'SET_LANE_GROUP', payload: { laneId: streamId, groupId: group.groupId } });
+          const lane = state.performanceLanes.find(l => l.id === streamId);
+          groupIds.add(lane?.groupId ?? null);
+        }
+        const allInSameGroup = groupIds.size === 1 && !groupIds.has(null);
+
+        if (allInSameGroup) {
+          // Ungroup: remove streams from their group
+          for (const streamId of selectedStreamIds) {
+            dispatch({ type: 'SET_LANE_GROUP', payload: { laneId: streamId, groupId: null } });
+          }
+        } else {
+          // Group: create a new group and assign all selected streams
+          const group: LaneGroup = {
+            groupId: generateId('grp'),
+            name: `Group ${state.laneGroups.length + 1}`,
+            color: COLOR_PALETTE[state.laneGroups.length % COLOR_PALETTE.length],
+            orderIndex: state.laneGroups.length,
+            isCollapsed: false,
+          };
+          dispatch({ type: 'CREATE_LANE_GROUP', payload: group });
+          for (const streamId of selectedStreamIds) {
+            dispatch({ type: 'SET_LANE_GROUP', payload: { laneId: streamId, groupId: group.groupId } });
+          }
         }
         setSelectedStreamIds(new Set());
       }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [selectedStreamIds, state.laneGroups.length, dispatch]);
+  }, [selectedStreamIds, state.laneGroups.length, state.performanceLanes, dispatch]);
 
   // Drag-to-reorder state
   const [reorderTarget, setReorderTarget] = useState<string | null>(null);
@@ -264,7 +280,7 @@ export function VoicePalette() {
           {ungroupedAssigned.length > 0 && (
             <div className="space-y-0.5 mt-2">
               <span className="section-header px-2">
-                On Grid ({ungroupedAssigned.length})
+                Ungrouped ({ungroupedAssigned.length})
               </span>
               {ungroupedAssigned.map(s => renderStreamRow(s))}
             </div>
@@ -437,7 +453,6 @@ function StreamRow({
   onReorderDrop: () => void;
   isReorderTarget: boolean;
 }) {
-  const solverFinger = solverAssignment?.label ?? null;
   const [showColorPicker, setShowColorPicker] = useState(false);
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState(stream.name);
@@ -565,20 +580,20 @@ function StreamRow({
           {isLocked && <span className="text-[8px] text-amber-400" title="Placement locked">&#x1F512;</span>}
           {formatPadPosition(padKeys[0])}
           {padKeys.length > 1 && `+${padKeys.length - 1}`}
-          {solverFinger && !voiceConstraint && (
-            <span className="ml-1 text-[8px] opacity-60">({solverFinger})</span>
-          )}
         </span>
       )}
 
-      {/* Finger assignment — only show explicit user constraints (not solver suggestions) */}
+      {/* Finger assignment — show user constraint or solver suggestion */}
       <div onClick={e => e.stopPropagation()} onMouseDown={e => e.stopPropagation()}>
         <FingerAssignmentInput
           value={
             voiceConstraint?.hand && voiceConstraint?.finger
               ? { hand: voiceConstraint.hand, finger: voiceConstraint.finger as FingerType }
-              : null
+              : solverAssignment
+                ? { hand: solverAssignment.hand as HandSide, finger: solverAssignment.finger as FingerType }
+                : null
           }
+          isSuggestion={!(voiceConstraint?.hand && voiceConstraint?.finger) && !!solverAssignment}
           onChange={(assignment: FingerAssignmentValue | null) => {
             if (assignment) {
               onSetConstraint(assignment.hand, assignment.finger);

--- a/src/ui/components/shared/FingerAssignmentInput.tsx
+++ b/src/ui/components/shared/FingerAssignmentInput.tsx
@@ -43,9 +43,11 @@ interface FingerAssignmentInputProps {
   value: FingerAssignmentValue | null | undefined;
   onChange: (assignment: FingerAssignmentValue | null) => void;
   size?: 'sm' | 'md';
+  /** When true, the value is a solver suggestion (displayed at reduced opacity). */
+  isSuggestion?: boolean;
 }
 
-export function FingerAssignmentInput({ value, onChange, size = 'sm' }: FingerAssignmentInputProps) {
+export function FingerAssignmentInput({ value, onChange, size = 'sm', isSuggestion = false }: FingerAssignmentInputProps) {
   const displayValue = value ? fingerAssignmentLabel(value) : '';
   const [editing, setEditing] = useState(false);
   const [editText, setEditText] = useState(displayValue);
@@ -113,13 +115,16 @@ export function FingerAssignmentInput({ value, onChange, size = 'sm' }: FingerAs
         color: value
           ? value.hand === 'left' ? '#6da3f5' : '#f09060'
           : 'var(--text-tertiary)',
+        opacity: isSuggestion ? 0.5 : 1,
       }}
       onClick={() => {
         setEditText(displayValue);
         setEditing(true);
       }}
       title={value
-        ? `${value.hand} ${value.finger} — click to edit`
+        ? isSuggestion
+          ? `Solver suggestion: ${value.hand} ${value.finger} — click to override`
+          : `${value.hand} ${value.finger} — click to edit`
         : 'Click to assign finger (e.g. L1, R5)'}
     >
       {value ? fingerAssignmentLabel(value) : '··'}

--- a/src/ui/pages/ProjectLibraryPage.tsx
+++ b/src/ui/pages/ProjectLibraryPage.tsx
@@ -186,7 +186,6 @@ export function ProjectLibraryPage() {
                   key={entry.id}
                   project={entry}
                   projectState={projectStates.get(entry.id) ?? null}
-                  mockData={getProjectMockData(entry.id)}
                   onOpen={() => navigate(`/project/${entry.id}`)}
                   onDelete={() => handleRemoveFromHistory(entry.id)}
                 />

--- a/src/ui/persistence/indexedDbStore.ts
+++ b/src/ui/persistence/indexedDbStore.ts
@@ -100,14 +100,30 @@ export async function listAllProjects(): Promise<ProjectIndexEntry[]> {
     const request = store.getAll();
     request.onsuccess = () => {
       const projects = request.result as PersistedProject[];
-      const entries: ProjectIndexEntry[] = projects.map(p => ({
-        id: p.id,
-        name: p.name,
-        createdAt: p.createdAt,
-        updatedAt: p.updatedAt,
-        soundCount: p.soundStreams.length,
-        eventCount: p.soundStreams.reduce((sum, s) => sum + s.events.length, 0),
-      }));
+      const entries: ProjectIndexEntry[] = projects.map(p => {
+        const eventCount = p.soundStreams.reduce((sum, s) => sum + s.events.length, 0);
+        // Compute duration in bars from events
+        let maxTime = 0;
+        for (const s of p.soundStreams) {
+          for (const e of s.events) {
+            const end = e.startTime + e.duration;
+            if (end > maxTime) maxTime = end;
+          }
+        }
+        const beatDuration = 60 / (p.bpm || 120);
+        const barDuration = beatDuration * 4;
+        const durationBars = barDuration > 0 ? Math.ceil(maxTime / barDuration) : 0;
+        return {
+          id: p.id,
+          name: p.name,
+          createdAt: p.createdAt,
+          updatedAt: p.updatedAt,
+          soundCount: p.soundStreams.length,
+          eventCount,
+          tempo: p.bpm || 120,
+          durationBars,
+        };
+      });
       // Sort by updatedAt descending
       entries.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
       resolve(entries);

--- a/src/ui/persistence/persistedProject.ts
+++ b/src/ui/persistence/persistedProject.ts
@@ -93,4 +93,6 @@ export interface ProjectIndexEntry {
   updatedAt: string;
   soundCount: number;
   eventCount: number;
+  tempo: number;
+  durationBars: number;
 }


### PR DESCRIPTION
## Summary

- **Sounds panel**: Solver finger suggestions now display in the editable FingerAssignmentInput box (at reduced opacity) instead of as parenthesized text like "(L2)". Users can click to override.
- **Timeline width**: Fixed recurring issue where timeline didn't fill container width after MIDI import by re-measuring on `totalDuration` change.
- **Timeline labels**: Note pills now show hand+finger (e.g., "L2") instead of just the number ("2").
- **Timeline selection**: Clicking any note now highlights all notes at the same time position (moment-based selection).
- **Grid finger toggle**: "Show Finger Assignment" toggle now displays solver-assigned fingers, not just user-set constraints.
- **Sound grouping**: Renamed confusing "On Grid" section to "Ungrouped". Cmd+G now toggles: groups ungrouped sounds, ungroups if all selected are in same group.
- **Events tab**: Compact event labels ("01" vs "Event 01") with column header row (#, Beat, Cost, Notes).
- **Project Library**: Cards show real data (BPM, sounds, bars, events, created/last visited dates) instead of mock data.
- **CLAUDE.md**: Added "UI Non-Regression Rules" section to prevent recurring regressions.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes (3 pre-existing failures unrelated to this PR)
- [ ] Import MIDI → verify timeline fills full container width
- [ ] Run solver → verify finger assignments appear in Sounds panel editable boxes (faded)
- [ ] Verify timeline pills show "L2" not "2"
- [ ] Click a timeline pill → verify all notes at same time highlight
- [ ] Toggle "Show Finger Assignment" in grid settings → verify solver fingers appear
- [ ] Group sounds with Cmd+G → select grouped sounds → Cmd+G ungroups them
- [ ] Check Events tab shows compact header and "01" format
- [ ] Check Project Library cards show BPM, sound count, bars, events, dates

https://claude.ai/code/session_018iixCsecYBdoc1W9kvyFzM