### PR TITLE
Enforce solver geometry in canonical evaluation and pose construction

### DIFF
--- a/docs/optimization/BIOMECHANICAL_ENGINE.md
+++ b/docs/optimization/BIOMECHANICAL_ENGINE.md
@@ -342,6 +342,10 @@ For full-performance decisions, inspect at least:
 5. peak moments and transition records; and
 6. baseline-relative differences when selecting a Candidate Solution.
 
+The canonical evaluator attributes a non-finite transition to its destination
+moment as an infeasibility. A speed-limit violation therefore cannot retain a
+`feasible` verdict merely because every Sound has a pad and finger owner.
+
 ## Configuration and tuning
 
 | Parameter | Default/current value | Effect |
@@ -392,9 +396,9 @@ These are current implementation facts, not desired future behavior:
 1. **The solver and canonical evaluator use different pose-naturalness
    formulas.** Beam uses translation-invariant shape deviation plus raw finger
    preference; post-hoc evaluation uses weighted centroid/home/finger terms.
-2. **Post-hoc grip classification checks span only.** `buildMomentPoses` does not
-   re-run topology, thumb, outward-rotation, collision, reach, or zone checks.
-   The beam generator applies more geometry than independent validation.
+2. **Post-hoc and solver grip geometry are aligned.** `buildMomentPoses` reuses
+   the strict CLP predicate and additionally rejects duplicate simultaneous
+   finger ownership and wrong-hand zones. Reach remains a transition concern.
 3. **Transition speed is centroid-based.** A shared finger can move very far and
    incur a large soft cost without independently triggering `Infinity` when the
    centroid remains under 12 units/s.

--- a/src/engine/evaluation/canonicalEvaluator.ts
+++ b/src/engine/evaluation/canonicalEvaluator.ts
@@ -321,8 +321,8 @@ export function evaluatePerformance(input: EvaluatePerformanceInput): Performanc
   const eventCosts: EventCostBreakdown[] = [];
   const transitionCosts: TransitionCostBreakdown[] = [];
   let totalCost = 0;
-  let hardMomentCount = 0;
-  let infeasibleMomentCount = 0;
+  const hardMomentIndices = new Set<number>();
+  const infeasibleMomentIndices = new Set<number>();
   let leftCount = 0;
   let rightCount = 0;
 
@@ -349,10 +349,10 @@ export function evaluatePerformance(input: EvaluatePerformanceInput): Performanc
 
     // Track feasibility
     if (eventResult.feasibilityTier === 'fallback') {
-      hardMomentCount++;
+      hardMomentIndices.add(i);
     }
     if (eventResult.noteAssignments.length < moment.notes.length) {
-      infeasibleMomentCount++;
+      infeasibleMomentIndices.add(i);
     }
 
     // Update running state
@@ -375,6 +375,12 @@ export function evaluatePerformance(input: EvaluatePerformanceInput): Performanc
 
       transitionCosts.push(transitionResult);
       totalCost += transitionResult.dimensions.total;
+      // A speed-limit violation is a hard feasibility failure, not merely an
+      // expensive transition. Attribute it to the destination moment.
+      if (!Number.isFinite(transitionResult.dimensions.transitionCost)) {
+        hardMomentIndices.add(i + 1);
+        infeasibleMomentIndices.add(i + 1);
+      }
     }
   }
 
@@ -403,16 +409,16 @@ export function evaluatePerformance(input: EvaluatePerformanceInput): Performanc
     averageDimensions,
     peakDimensions,
     peakMomentIndex,
-    hardMomentCount,
-    infeasibleMomentCount,
+    hardMomentCount: hardMomentIndices.size,
+    infeasibleMomentCount: infeasibleMomentIndices.size,
     momentCount: moments.length,
     transitionCount: transitionCosts.length,
   };
 
   const feasibility = deriveFeasibilityVerdict(
-    infeasibleMomentCount,
-    hardMomentCount,
-    infeasibleMomentCount,
+    infeasibleMomentIndices.size,
+    hardMomentIndices.size,
+    infeasibleMomentIndices.size,
     eventCosts.filter(e => e.feasibilityTier === 'fallback').length,
     moments.length,
   );

--- a/src/engine/evaluation/poseBuilder.ts
+++ b/src/engine/evaluation/poseBuilder.ts
@@ -11,11 +11,8 @@ import { type FingerCoordinate, type HandPose } from '../../types/performance';
 import { parsePadKey } from '../../types/padGrid';
 import { type PadFingerAssignment } from '../../types/executionPlan';
 import { type ConstraintTier } from '../prior/feasibility';
-import {
-  FINGER_PAIR_MAX_SPAN_STRICT,
-  MAX_FINGER_SPAN_STRICT,
-  pairKey,
-} from '../prior/biomechanicalModel';
+import { isStrictGripValid } from '../prior/feasibility';
+import { isZoneValid } from '../surface/handZone';
 
 // ============================================================================
 // Pose Construction
@@ -48,6 +45,8 @@ export function buildMomentPoses(
   const leftFingers: Partial<Record<FingerType, FingerCoordinate>> = {};
   const rightFingers: Partial<Record<FingerType, FingerCoordinate>> = {};
   const unmappedPads: string[] = [];
+  let assignmentCollision = false;
+  let zoneViolation = false;
 
   for (const padKey of activePadKeys) {
     const owner = assignment[padKey];
@@ -65,8 +64,12 @@ export function buildMomentPoses(
     const fingerCoord: FingerCoordinate = { x: coord.col, y: coord.row };
 
     if (owner.hand === 'left') {
+      if (leftFingers[owner.finger]) assignmentCollision = true;
+      if (!isZoneValid(coord, 'left')) zoneViolation = true;
       leftFingers[owner.finger] = fingerCoord;
     } else {
+      if (rightFingers[owner.finger]) assignmentCollision = true;
+      if (!isZoneValid(coord, 'right')) zoneViolation = true;
       rightFingers[owner.finger] = fingerCoord;
     }
   }
@@ -79,7 +82,9 @@ export function buildMomentPoses(
     ? buildHandPose(rightFingers)
     : null;
 
-  const tier = classifyGripTier(leftFingers, rightFingers);
+  const tier = assignmentCollision || zoneViolation
+    ? 'fallback'
+    : classifyGripTier(leftFingers, rightFingers);
 
   return { left, right, tier, unmappedPads };
 }
@@ -105,33 +110,15 @@ function buildHandPose(
 /**
  * Determines the constraint tier for the given finger positions.
  * V1 Cost Model (D-01): Only strict tier exists. Returns 'strict' if all
- * finger pairs pass strict span limits, 'fallback' otherwise.
+ * hand poses pass every strict CLP geometry rule, 'fallback' otherwise.
  */
 function classifyGripTier(
   leftFingers: Partial<Record<FingerType, FingerCoordinate>>,
   rightFingers: Partial<Record<FingerType, FingerCoordinate>>,
 ): ConstraintTier {
-  const strictOk = checkSpan(leftFingers, FINGER_PAIR_MAX_SPAN_STRICT)
-    && checkSpan(rightFingers, FINGER_PAIR_MAX_SPAN_STRICT);
+  const strictOk = (Object.keys(leftFingers).length === 0 || isStrictGripValid(leftFingers, 'left'))
+    && (Object.keys(rightFingers).length === 0 || isStrictGripValid(rightFingers, 'right'));
   return strictOk ? 'strict' : 'fallback';
-}
-
-function checkSpan(
-  fingers: Partial<Record<FingerType, FingerCoordinate>>,
-  pairMaxSpan: Record<string, number>,
-): boolean {
-  const entries = Object.entries(fingers) as [FingerType, FingerCoordinate][];
-  for (let i = 0; i < entries.length; i++) {
-    for (let j = i + 1; j < entries.length; j++) {
-      const key = pairKey(entries[i][0], entries[j][0]);
-      const max = pairMaxSpan[key] ?? MAX_FINGER_SPAN_STRICT;
-      const dx = entries[i][1].x - entries[j][1].x;
-      const dy = entries[i][1].y - entries[j][1].y;
-      const dist = Math.sqrt(dx * dx + dy * dy);
-      if (dist > max) return false;
-    }
-  }
-  return true;
 }
 
 /**

--- a/src/engine/prior/feasibility.ts
+++ b/src/engine/prior/feasibility.ts
@@ -467,6 +467,30 @@ function satisfiesVerticalRotationConstraint(
 }
 
 /**
+ * Validate an already-assigned simultaneous grip with the exact hard geometry
+ * used by CLP grip generation.  Post-hoc evaluators must use this rather than
+ * reimplementing only a subset of the constraints, otherwise an optimizer can
+ * rank an assignment that the solver could never produce.
+ */
+export function isStrictGripValid(
+  fingerPositions: Partial<Record<FingerType, FingerCoordinate>>,
+  hand: HandSide,
+): boolean {
+  const positions = Object.values(fingerPositions);
+  if (positions.length === 0 || positions.length > 5) return false;
+
+  const occupiedPads = new Set(positions.map(pos => `${pos.x},${pos.y}`));
+  if (occupiedPads.size !== positions.length) return false;
+  if (!satisfiesSpanConstraint(fingerPositions)) return false;
+
+  const topologyValid = hand === 'left'
+    ? satisfiesLeftHandTopology(fingerPositions)
+    : satisfiesRightHandTopology(fingerPositions);
+
+  return topologyValid && satisfiesVerticalRotationConstraint(fingerPositions);
+}
+
+/**
  * Calculates the centroid of a set of finger positions.
  */
 function calculateCentroid(

--- a/src/ui/validator/validatorScenarios.ts
+++ b/src/ui/validator/validatorScenarios.ts
@@ -290,14 +290,12 @@ const SCENARIOS: ValidatorScenario[] = [
     const vB = makeVoice('v9-b', 'Sound B', 65, '#3b82f6');
     const vC = makeVoice('v9-c', 'Sound C', 71, '#22c55e');
     const layout = makeLayout('v9-layout', 'Valid But Degraded', [
-      { row: 3, col: 2, voice: vA },
-      { row: 3, col: 5, voice: vB },
-      { row: 4, col: 3, voice: vC },
+      { row: 3, col: 3, voice: vA },
+      { row: 3, col: 6, voice: vB },
+      { row: 4, col: 4, voice: vC },
     ]);
-    // thumb(2) < middle(3) < pinky(5) for right hand — valid ordering
-    // thumb-pinky = sqrt((5-2)^2) = 3.0 ≤ 5.5 OK
-    // thumb-middle = sqrt((3-2)^2 + (4-3)^2) = sqrt(2) ≈ 1.41 ≤ 4.5 OK
-    // middle-pinky = sqrt((5-3)^2 + (3-4)^2) = sqrt(5) ≈ 2.24 ≤ 2.5 OK
+    // All pads are in the right-hand zone; thumb(3) < middle(4) < pinky(6).
+    // Pair spans remain within their strict limits.
     return {
       id: 'V9',
       title: 'Valid But Degraded: High Cost, Feasible',
@@ -305,14 +303,14 @@ const SCENARIOS: ValidatorScenario[] = [
       constraintIds: ['span'] as const,
       layout,
       padFingerAssignment: {
-        [padKey(3, 2)]: { hand: 'right', finger: 'thumb' },
-        [padKey(4, 3)]: { hand: 'right', finger: 'middle' },
-        [padKey(3, 5)]: { hand: 'right', finger: 'pinky' },
+        [padKey(3, 3)]: { hand: 'right', finger: 'thumb' },
+        [padKey(4, 4)]: { hand: 'right', finger: 'middle' },
+        [padKey(3, 6)]: { hand: 'right', finger: 'pinky' },
       } satisfies PadFingerAssignment,
       moment: makeMoment([
-        makeNote(vA.id, padKey(3, 2), 62),
-        makeNote(vB.id, padKey(3, 5), 65),
-        makeNote(vC.id, padKey(4, 3), 71),
+        makeNote(vA.id, padKey(3, 3), 62),
+        makeNote(vB.id, padKey(3, 6), 65),
+        makeNote(vC.id, padKey(4, 4), 71),
       ]),
       expectedInitialStatus: 'valid',
     } satisfies ValidatorScenario;

--- a/test/engine/evaluation/canonicalEvaluator.test.ts
+++ b/test/engine/evaluation/canonicalEvaluator.test.ts
@@ -168,6 +168,27 @@ describe('poseBuilder', () => {
     const result = buildMomentPoses([padKey(3, 4), padKey(3, 5)], assignment);
     expect(result.tier).toBe('strict');
   });
+
+  it('rejects simultaneous pads assigned to the same finger', () => {
+    const assignment: PadFingerAssignment = {
+      [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+      [padKey(3, 5)]: { hand: 'right', finger: 'index' },
+    };
+    expect(buildMomentPoses([padKey(3, 4), padKey(3, 5)], assignment).tier).toBe('fallback');
+  });
+
+  it('applies topology and hand-zone rules used by the solver', () => {
+    const crossed: PadFingerAssignment = {
+      [padKey(3, 4)]: { hand: 'right', finger: 'index' },
+      [padKey(3, 3)]: { hand: 'right', finger: 'middle' },
+    };
+    const wrongZone: PadFingerAssignment = {
+      [padKey(3, 1)]: { hand: 'right', finger: 'index' },
+    };
+
+    expect(buildMomentPoses([padKey(3, 4), padKey(3, 3)], crossed).tier).toBe('fallback');
+    expect(buildMomentPoses([padKey(3, 1)], wrongZone).tier).toBe('fallback');
+  });
 });
 
 // ============================================================================
@@ -436,6 +457,32 @@ describe('evaluatePerformance', () => {
 
     expect(result.feasibility).toBeDefined();
     expect(['feasible', 'degraded', 'infeasible']).toContain(result.feasibility.level);
+  });
+
+  it('marks an over-speed transition as infeasible', () => {
+    const layout: Layout = {
+      ...makeSimpleLayout(),
+      padToVoice: {
+        [padKey(0, 3)]: makeVoice(40),
+        [padKey(7, 7)]: makeVoice(41),
+      },
+    };
+    const assignment: PadFingerAssignment = {
+      [padKey(0, 3)]: { hand: 'right', finger: 'index' },
+      [padKey(7, 7)]: { hand: 'right', finger: 'index' },
+    };
+    const moments = [
+      makeMoment(0, 0, [makeNote('voice-40', 40, padKey(0, 3))]),
+      makeMoment(1, 0.1, [makeNote('voice-41', 41, padKey(7, 7))]),
+    ];
+
+    const result = evaluatePerformance({
+      moments, layout, padFingerAssignment: assignment, config: makeConfig(),
+    });
+
+    expect(result.transitionCosts[0].dimensions.transitionCost).toBe(Infinity);
+    expect(result.aggregateMetrics.infeasibleMomentCount).toBe(1);
+    expect(result.feasibility.level).toBe('infeasible');
   });
 
   it('should handle empty performance', () => {


### PR DESCRIPTION
### Motivation
- Align post-hoc evaluation with the solver's strict CLP geometry so the evaluator cannot rank assignments that the beam solver would reject. 
- Ensure moment-level feasibility reflects both grip geometry (ordering, span, outward rotation, collisions, zones) and non-finite transition (overspeed) failures. 
- Harden validator fixtures and test coverage to prevent regressions where a high-cost but feasible scenario is misclassified.

### Description
- Add a canonical strict-grip predicate `isStrictGripValid` in `src/engine/prior/feasibility.ts` that enforces capacity, per-pair span, topology, and outward-rotation rules for an assigned simultaneous grip. 
- Update `buildMomentPoses` in `src/engine/evaluation/poseBuilder.ts` to detect simultaneous same-finger collisions and wrong-hand zone assignments and to use the strict-grip predicate when classifying grip tiers. 
- Change `evaluatePerformance` in `src/engine/evaluation/canonicalEvaluator.ts` to treat non-finite transition costs as infeasible destination moments and to use sets of moment indices to avoid double-counting feasibility failures. 
- Update validator fixture `V9` in `src/ui/validator/validatorScenarios.ts`, extend unit tests in `test/engine/evaluation/canonicalEvaluator.test.ts` to cover same-finger collisions, topology/zone rejections, and overspeed transitions, and update docs in `docs/optimization/BIOMECHANICAL_ENGINE.md` to reflect the aligned behavior.

### Testing
- Ran the focused test suites with `npm test -- --run test/validator/validatorEngine.test.ts test/validator/validatorScenarios.test.ts test/engine/evaluation/canonicalEvaluator.test.ts` and all of those tests passed. 
- Ran type checking with `npm run typecheck` and the project typecheck succeeded. 
- Ran broader test suite runs and linters (`npm test -- --run` / `git diff --check`); the targeted biomechanical and validator suites are passing, and a pre-existing long-running greedy-candidate integration test may time out under the suite's current 60s limit (not related to the geometry fixes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a868c0f55b0832189a0e46535472ff2)